### PR TITLE
Route new issues through forms and triage them automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,22 @@
+# Force every issue through one of the forms, so nothing arrives unlabelled
+# and bug reports always carry the Foundry, dnd5e and Item Piles versions
+# needed to reproduce them.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Item Piles support
+    url: https://github.com/fantasycalendar/FoundryVTT-ItemPiles/issues
+    about: >-
+      Merchant windows, currency handling, buying and selling are Item Piles
+      features. If the problem is with how a merchant sheet behaves rather
+      than with this module's shops or stock, report it there.
+  - name: Foundry VTT help and general questions
+    url: https://foundryvtt.com/community/
+    about: >-
+      Questions about Foundry or dnd5e in general rather than a bug in this
+      module. The community links there will get you a faster answer.
+  - name: What ships in this module
+    url: https://github.com/mikiross87/merchant-presets#readme
+    about: >-
+      The README lists the shops, what they stock, and why everything comes
+      from SRD 5.2 rather than the paid books.

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,46 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_URL: ${{ vars.PROJECT_URL }}
+    # Inert until both are configured, so the workflow never fails a repo
+    # (or a fork) that has no project set up. Same pattern the release
+    # workflow uses for the Foundry registry token.
+    #
+    # To switch it on:
+    #   1. Create a user or org Project and copy its URL, e.g.
+    #      https://github.com/users/mikiross87/projects/1
+    #   2. Add it as a repository *variable* named PROJECT_URL
+    #      (Settings > Secrets and variables > Actions > Variables).
+    #   3. Create a fine-grained PAT with the Projects permission set to
+    #      "Read and write", plus Issues "Read-only" on this repository, and
+    #      add it as a repository *secret* named PROJECT_PAT.
+    #      GITHUB_TOKEN cannot write to Projects, which is why a PAT is needed.
+    if: ${{ github.event.repository.fork == false }}
+    steps:
+      - name: Check configuration
+        id: check
+        run: |
+          set -euo pipefail
+          if [ -n "$PROJECT_PAT" ] && [ -n "$PROJECT_URL" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_PAT and/or PROJECT_URL not set - skipping."
+          fi
+
+      - uses: actions/add-to-project@v1
+        if: steps.check.outputs.configured == 'true'
+        with:
+          project-url: ${{ vars.PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_PAT }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"   # Mondays, 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Deliberately scoped to issues already waiting on the reporter.
+          # Untriaged issues are the maintainer's backlog, not the reporter's
+          # fault, and closing those would lose real reports.
+          only-labels: needs-repro
+          days-before-issue-stale: 21
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This has been waiting on a reproduction with other modules disabled
+            for three weeks. Item Piles and itempilesdnd5e should stay enabled —
+            they are required — but if it still happens with everything else
+            off, say so and it stays open. Otherwise it will close in fourteen
+            days. Reopening is always fine.
+          close-issue-message: >
+            Closing for now, since there is still no reproduction with other
+            modules disabled. If you hit this again, comment here with what you
+            found and it will be reopened.
+          # Pull requests are reviewed, not chased.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,113 @@
+name: Triage
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      ISSUE: ${{ github.event.issue.number }}
+      # Never interpolate ${{ github.event.issue.* }} straight into a run block:
+      # an issue body is attacker-controlled text and the shell would evaluate
+      # it. Passing it through the environment keeps it inert data.
+      BODY: ${{ github.event.issue.body }}
+      # Labels as they stood when the event fired, which is what lets the
+      # "have we already said this?" checks work on the edited re-run.
+      LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+    steps:
+      # Needed only to read the Item Piles minimum out of module.json.
+      - uses: actions/checkout@v7
+
+      - name: Label and comment from the form answers
+        run: |
+          set -euo pipefail
+
+          # Issue forms render as "### <label>" followed by the value, so the
+          # first non-empty line after a heading is the answer for the single
+          # line fields (input, dropdown). Feature requests carry none of the
+          # fields read below and simply fall through untouched.
+          field() {
+            awk -v h="### $1" '
+              $0 == h { grab = 1; next }
+              /^### / { grab = 0 }
+              grab { print }
+            ' <<< "$BODY" | sed '/^[[:space:]]*$/d' | head -1
+          }
+
+          has_label() {
+            printf '%s' ",$LABELS," | grep -q ",$1,"
+          }
+
+          # Strip a leading v and any prerelease suffix. sort -V orders
+          # prerelease suffixes differently between BSD and GNU sort, and that
+          # precision is not worth an implementation dependency here.
+          release_triple() {
+            printf '%s' "$1" | tr -d '[:space:]' | sed 's/^[vV]//; s/-.*//'
+          }
+
+          # Is $1 strictly older than $2? Both must already be x.y.z.
+          is_older() {
+            [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+          }
+
+          NOTES=""
+          add_note() { NOTES="${NOTES}${1}"$'\n\n'; }
+
+          # 1. Reporter has not ruled out a conflict with another module.
+          ISOLATED="$(field "Does it still happen with other modules disabled?")"
+          if printf '%s' "$ISOLATED" | grep -q '^Haven'; then
+            echo "not isolated yet -> needs-repro"
+            gh issue edit "$ISSUE" -R "$REPO" --add-label needs-repro
+          fi
+
+          # 2. Reported against a module version older than the current release.
+          RAW="$(field "Merchant Presets version")"
+          REPORTED="$(release_triple "$RAW")"
+          if printf '%s' "$REPORTED" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            LATEST="$(release_triple "$(gh api "repos/$REPO/releases/latest" -q .tag_name)")"
+            echo "module reported=$REPORTED latest=$LATEST"
+            if is_older "$REPORTED" "$LATEST"; then
+              if ! has_label outdated; then
+                add_note "This is filed against Merchant Presets \`$REPORTED\`, and the current release is \`$LATEST\`. Could you update and check whether it still happens? A fair number of reports turn out to be already fixed."
+              fi
+              gh issue edit "$ISSUE" -R "$REPO" --add-label outdated
+            fi
+          else
+            echo "no usable module version in the report ('$RAW')"
+          fi
+
+          # 3. Item Piles below the minimum this module declares. The field is
+          # free text asking for two versions, so match "Item Piles <x.y.z>"
+          # while refusing to match "itempilesdnd5e <x.y.z>" — the "dnd5e"
+          # after the name means the version pattern cannot follow. Anything
+          # not confidently parsed is skipped rather than guessed at.
+          IP_MIN="$(jq -r '.relationships.requires[]? | select(.id == "item-piles") | .compatibility.minimum // empty' module.json)"
+          IP_RAW="$(field "Item Piles and itempilesdnd5e versions")"
+          IP_MATCH="$(printf '%s' "$IP_RAW" | grep -oiE 'item[[:space:]_-]*piles[[:space:]v:]*[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          IP_VER="$(printf '%s' "$IP_MATCH" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+          if [ -n "$IP_MIN" ] && [ -n "$IP_VER" ]; then
+            echo "item-piles reported=$IP_VER minimum=$IP_MIN"
+            if is_older "$IP_VER" "$IP_MIN"; then
+              if ! has_label needs-itempiles-update; then
+                add_note "This module requires Item Piles \`$IP_MIN\` or newer, and the report lists \`$IP_VER\`. Please update Item Piles and check whether the problem persists — several merchant behaviours depend on it."
+              fi
+              gh issue edit "$ISSUE" -R "$REPO" --add-label needs-itempiles-update
+            fi
+          else
+            echo "item-piles version not confidently parsed from '$IP_RAW' (minimum='$IP_MIN') - skipping"
+          fi
+
+          # One comment carrying whatever is new, rather than one per finding.
+          if [ -n "$NOTES" ]; then
+            gh issue comment "$ISSUE" -R "$REPO" --body "$(printf '%s' "Thanks for the report."$'\n\n'"$NOTES")"
+          else
+            echo "nothing new to comment"
+          fi


### PR DESCRIPTION
# What does this PR change?

Issue handling only — no module content, no pack changes.

Brings this repo in line with light-presets, where this was built first. CI here is already *ahead* of that repo (JSON validation, pack build, paid-content guard) and `release.yml` matches it plus pack building, so neither needed touching. What was missing was everything that happens after an issue is opened.

**`ISSUE_TEMPLATE/config.yml`** sets `blank_issues_enabled: false`. Blank issues were on, so anyone could bypass both forms and open an unlabelled report with no Foundry version, no dnd5e version, and no Item Piles version. Contact links route merchant-sheet behaviour to the Item Piles tracker where it belongs, general Foundry questions to the community, and "what ships in this module" to the README.

**`triage.yml`** runs on `issues: [opened, edited]` and adds:

| Label | When |
|---|---|
| `needs-repro` | reporter picked "Haven't tried" on the other-modules-disabled dropdown |
| `outdated` | reported module version is behind the current release |
| `needs-itempiles-update` | reported Item Piles version is below the `relationships.requires` minimum in `module.json` |

The third is **new here rather than ported** — your own form says most issues involve Item Piles. That field asks for two versions as free text, so the match accepts `Item Piles <x.y.z>` while refusing `itempilesdnd5e <x.y.z>`; anything not confidently parsed is skipped rather than guessed at. Findings are collected into one comment rather than one per finding, and each is suppressed individually if its label is already present, so an edit that reveals a second problem still gets mentioned.

**`stale.yml`** is scoped `only-labels: needs-repro`, 21 days to stale and 14 more to close, PRs exempt. Its message notes that Item Piles and itempilesdnd5e must stay enabled, since they're required.

**`add-to-project.yml`** ships inert, gated on `PROJECT_URL` (variable) and `PROJECT_PAT` (secret) — `GITHUB_TOKEN` cannot write to Projects. Setup steps are in the file.

Labels `needs-repro`, `outdated`, `stale` and `needs-itempiles-update` already exist on the repository.

## Verification

All five workflows parse as YAML. The Item Piles parser was exercised against ten realistic inputs — both version orderings, `item-piles` / `ItemPiles` / `item piles:` spellings, `v`-prefixes, and four inputs it should refuse (bare numbers, "latest versions of both", a two-component version, and an `itempilesdnd5e`-only line, which must not be misread as Item Piles). It never picked up the wrong version and skipped every ambiguous case.

Not verified end to end: `issues`-triggered workflows only run from the **default branch**, so none of this executes until merge. I'll open a throwaway issue afterwards and delete it.

## Checklist

- [x] Change is limited to `.github/` — no module content, no pack rebuild needed
- [x] No version bump in `module.json`
