### PR TITLE
Stop load_srd indexing the equipment pack's folders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,16 @@ Document ids are content-derived hashes and the stock rolls are seeded per item,
 so regenerating reproduces the same packs rather than churning them. A stock line
 naming an item that is not in the SRD is reported and skipped, not guessed at.
 
-Two constraints worth knowing before changing the generator:
+Three constraints worth knowing before changing the generator:
 
 - Everything must resolve against **SRD 5.2** (`dnd5e.equipment24`). CI fails the
   build if any reference to the paid Player's Handbook or Dungeon Master's Guide
   modules appears in `_source` or `data`.
+- **`load_srd` skips folders.** The equipment pack ships 44 of them alongside its
+  items, and 43 share no name with any item — `Wands`, `Potions`, `Rods`,
+  `Scrolls`, `Tools`, `Holy Symbol`. Indexed by name they shadow the lookup, and
+  a stock line naming one would resolve to the folder and be embedded as an item
+  rather than being reported missing.
 - **Containers** cannot carry a quantity: dnd5e declares
   `quantity: new NumberField({min: 1, max: 1})`, because each container is a
   distinct object with its own contents. A shop with four pouches holds four

--- a/tools/build_srd.py
+++ b/tools/build_srd.py
@@ -49,6 +49,13 @@ def load_srd():
     best = {}
     for f in glob.glob(os.path.join(SRD, "*.json")):
         d = json.load(open(f))
+        # The pack ships its folders alongside its items, and 43 of them share
+        # no name with any item — Wands, Potions, Rods, Scrolls, Tools, Holy
+        # Symbol. Indexed by name they shadow the lookup: a stock line naming
+        # one would resolve to the folder and be embedded as an item, instead
+        # of being reported missing as this generator promises.
+        if d.get("_key", "").startswith("!folders!"):
+            continue
         k = norm(d["name"])
         sysd = d.get("system") or {}
         qty = sysd.get("quantity") or 1


### PR DESCRIPTION
`load_srd` indexes every document in the unpacked pack by name, **folders included**. The pack ships 44 of them, and 43 share no name with any item — `Wands`, `Potions`, `Rods`, `Scrolls`, `Tools`, `Holy Symbol`.

Indexed by name they shadow the lookup. A stock line named "Potions" would resolve to the folder and be embedded on a merchant as an item, silently, where CONTRIBUTING promises that a line naming something not in the SRD is reported and skipped. `load_goods` already filtered folders; `load_srd` did not.

**Nothing shipped hits this**: no recipe line uses one of those names, and a rebuild after the fix leaves `_source` byte-identical. It is a trap for the next stock line rather than a live bug.

Prerequisite for #2 — without it, `make_gear`'s name fallback resolves "Holy Symbol" to a folder id and emits a dangling pointer.