### PR TITLE
Open and close the shops on the world clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,22 @@ keeps 09:00–17:00, a dock opens at 05:00, the tavern runs 06:00 to 02:00, and
 the fence trades 20:00 to 04:00 — along with `refreshItemsOnOpen`, so the shop
 restocks each morning when the doors open.
 
-**This module fires them, not Item Piles.** Item Piles has the same feature but
-only triggers it through Simple Calendar, which it requires by name — so it will
-not fire from Foundry's built-in calendar or from Calendaria. This module drives
-the same restock off Foundry's own world clock instead, so anything that
-advances time works.
+**This module fires them, not Item Piles.** Item Piles has both features but
+reaches them only through Simple Calendar, which it requires by name — so
+neither fires from Foundry's built-in calendar or from Calendaria. Worse for the
+hours: when Simple Calendar is absent, Item Piles rewrites the merchant's status
+from *auto* back to *always open* and saves it, so the hours cannot even be left
+armed for later. Simple Calendar is unmaintained and does not support v14, which
+this module requires, so that route is shut for good rather than merely missing.
 
-**Off by default**, via the *Restock shops when they open* setting. A restock
-rebuilds the shelf from the shop's stock table, and Item Piles clears the
-merchant's existing items to do it — so anything you added to a shop by hand is
+This module therefore drives both off Foundry's own world clock, and anything
+that advances time works. The hours are **on by default**, via *Shops keep their
+trading hours*: a shop outside its hours closes to players, and the GM can still
+open the sheet. Turn the setting off for shops that never shut.
+
+Restocking, by contrast, is **off by default**, via the *Restock shops when they
+open* setting. A restock rebuilds the shelf from the shop's stock table, and Item
+Piles clears the merchant's existing items to do it — so anything you added by hand is
 discarded. Turn it on once your shops hold nothing you would miss. Only the
 designated GM runs the pass, the last processed world time is stored so a reload
 cannot re-fire one, and winding the clock backwards never restocks.
@@ -149,13 +156,15 @@ To restock one shop by hand, with the flags and purse restored:
 game.modules.get("merchant-presets").api.restock(actor)
 ```
 
-Not supported: **closed days and holiday restocks**. Those are built on Simple
-Calendar notes, which core has no equivalent for. The flags are shipped empty
-and will work if you ever install Simple Calendar.
+Not supported: **closed days and holidays**. Those are keyed to Simple Calendar
+notes, which core has no equivalent for, and Simple Calendar is not coming back
+for v14. The `closedDays` and `closedHolidays` flags ship empty and are left
+alone — a shop keeps the same hours every day of the year.
 
 Merchants ship with status `open` rather than `auto` deliberately: with `auto`
 and no Simple Calendar, Item Piles rewrites the flag on first render, which
-throws on a locked module compendium.
+throws on a locked module compendium. The module sets the status itself once a
+merchant is in the world, so the shipped value is only ever a starting point.
 - **Bundled goods** (Arrows ×20, Bolts ×20, Sling Bullets ×20, Needles ×50,
   Firearm Bullets ×10, Iron Spikes ×10) carry Item Piles' `quantityForPrice`,
   so a player pays the bundle price and receives the bundle. The Quantity column

--- a/scripts/merchant-presets.mjs
+++ b/scripts/merchant-presets.mjs
@@ -62,6 +62,13 @@ const log = (...args) => console.log(`${MODULE} |`, ...args);
 const rollStock = async formula =>
   Math.max(0, (await new Roll(formula).evaluate({ allowInteractive: false })).total);
 
+/** Whether this is one of our merchants, sitting in the world rather than a pack. */
+function isPreset(actor) {
+  if (!actor || actor.pack) return false;              // never touch compendium copies
+  return (foundry.utils.getProperty(actor, FLAG_PATH) ?? [])
+    .some(t => t?.uuid?.startsWith(STOCK_PREFIX));
+}
+
 /** An item's price expressed in gold pieces. */
 function priceInGp(item) {
   const p = item.system?.price ?? {};
@@ -184,14 +191,12 @@ async function applyStockMode(actor) {
  * @returns {Promise<boolean>} whether anything changed
  */
 async function rewire(actor) {
-  if (actor?.pack) return false;                       // never touch compendium copies
-  const isPreset = (foundry.utils.getProperty(actor, FLAG_PATH) ?? [])
-    .some(t => t?.uuid?.startsWith(STOCK_PREFIX));
-  if (!isPreset) return false;
+  if (!isPreset(actor)) return false;
 
   let changed = false;
   changed = await wireTables(actor) || changed;
   changed = await applyStockMode(actor) || changed;
+  changed = await syncOpenState(actor) || changed;
   if (changed) log(`prepared "${actor.name}"`);
   return changed;
 }
@@ -387,6 +392,65 @@ async function restockOnTimeChange(worldTime, previous) {
   return restocked.length;
 }
 
+/**
+ * Open and close the shops on the world clock.
+ *
+ * Every merchant ships with trading hours, and Item Piles can act on them —
+ * but only through Simple Calendar, which it requires by name. Worse, its
+ * `updateOpenCloseStatus` rewrites `status: "auto"` back to `"open"` and saves
+ * it when that module is absent, so the hours cannot even be left armed for
+ * later. Simple Calendar is unmaintained and does not support v14, which this
+ * module requires, so that path is closed for good rather than merely absent.
+ *
+ * Item Piles documents `open` and `closed` as first-class manual statuses,
+ * though, so drive those from Foundry's own clock — the same trick this module
+ * already plays for restocking, and using the same `isOpenAt` it reads the
+ * hours with. No patching, and any calendar that advances world time works.
+ *
+ * @param {Actor} actor
+ * @returns {Promise<boolean>} whether the status changed
+ */
+async function syncOpenState(actor) {
+  const pileData = foundry.utils.getProperty(actor, "flags.item-piles.data");
+  if (!pileData?.openTimes?.enabled) return false;
+
+  let wanted = "open";
+  if (game.settings.get(MODULE, "tradingHours")) {
+    const now = minuteOfDay(game.time.calendar.timeToComponents(game.time.worldTime));
+    wanted = isOpenAt(pileData, now) ? "open" : "closed";
+  }
+  // Turning the setting off hands the shops back always-open, rather than
+  // leaving whichever ones happened to be shut stuck that way.
+  if (pileData.openTimes.status === wanted) return false;
+  await actor.update({ "flags.item-piles.data.openTimes.status": wanted });
+  return true;
+}
+
+/**
+ * Put every merchant in the world on the right side of its own door.
+ * @returns {Promise<number>} how many changed
+ */
+async function syncOpenStateAll() {
+  if (game.users.activeGM !== game.user) return 0;     // one GM does the writing
+  let n = 0;
+  for (const actor of game.actors) {
+    if (!isPreset(actor)) continue;
+    try { if (await syncOpenState(actor)) n++; }
+    catch (err) { console.error(`${MODULE} | could not set open state on "${actor.name}"`, err); }
+  }
+  return n;
+}
+
+/** Wire trading hours to the world clock. Separate from restocking, which is off by default. */
+function registerTradingHours() {
+  if (!game.settings.get(MODULE, "tradingHours")) return;
+  Hooks.on("updateWorldTime", async () => {
+    if (game.users.activeGM !== game.user) return;
+    await syncOpenStateAll();
+  });
+  log(`trading hours active on the ${game.time.calendar.name ?? "world"} calendar`);
+}
+
 /** Wire restocking to the world clock. Only the designated GM acts. */
 function registerRestock() {
   if (!game.settings.get(MODULE, "autoRestock")) return;
@@ -488,6 +552,21 @@ Hooks.once("init", () => {
     scope: "world", config: false, type: Number, default: 0
   });
 
+  game.settings.register(MODULE, "tradingHours", {
+    name: "Shops keep their trading hours",
+    hint: "Every merchant ships with hours — a jeweler keeps 09:00-17:00, a dock opens at 05:00, "
+      + "a fence trades 20:00 to 04:00 — and closes to players outside them. Item Piles can do "
+      + "this itself, but only through Simple Calendar, which it requires by name and which is "
+      + "unmaintained and does not support v14; this module drives the same hours off Foundry's "
+      + "own world clock instead, so any calendar that advances time works. Turn it off and every "
+      + "shop stays open around the clock. Takes effect on reload.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: () => syncOpenStateAll()
+  });
+
   game.settings.register(MODULE, "drinksHydrate", {
     name: "Ale and wine slake thirst",
     hint: "With Simple Nutrition 5e installed, count ale and wine towards a character's water "
@@ -502,7 +581,7 @@ Hooks.once("init", () => {
 
 Hooks.once("ready", () => {
   game.modules.get(MODULE).api = { rewire, rewireAll, registerDrinks, restock, restockOnTimeChange, reapplyItemFlags,
-    reconcileContainers, replenishPurse };
+    reconcileContainers, replenishPurse, syncOpenState, syncOpenStateAll };
 
   // Every client evaluates its own nutrition candidates, so this must run for
   // players too — and it does not depend on Item Piles.
@@ -520,6 +599,10 @@ Hooks.once("ready", () => {
   });
 
   registerRestock();
+  registerTradingHours();
+  // Time moves while a world is closed, so put the shops on the right side of
+  // their doors now rather than at the next tick of the clock.
+  syncOpenStateAll().then(n => { if (n) log(`${n} shop(s) opened or closed for the hour`); });
 
   log("ready");
 });

--- a/tools/build_srd.py
+++ b/tools/build_srd.py
@@ -328,11 +328,13 @@ def main():
                                            "addAll": True, "timesToRoll": "1", "customCategory": "",
                                            "items": per_result}],
                     # Trading hours, and a restock each morning when the doors
-                    # open. Both are driven by Simple Calendar: without it
-                    # Item Piles never fires the refresh, and `status: "auto"`
-                    # would be rewritten to "open" on first sheet render — which
-                    # throws on a locked compendium. So ship an explicit "open"
-                    # and let the GM switch to auto once a calendar is present.
+                    # open. Item Piles reaches both only through Simple Calendar,
+                    # which it requires by name, and rewrites `status: "auto"`
+                    # back to "open" when that module is absent — a write that
+                    # throws on a locked compendium. Simple Calendar is
+                    # unmaintained and has no v14 build, so there is no calendar
+                    # to wait for: ship "open" and let the module's own runtime
+                    # drive the status off Foundry's clock instead.
                     "openTimes": {"enabled": True, "status": "open",
                                   "open":  {"hour": shop["hours"][0], "minute": 0},
                                   "close": {"hour": shop["hours"][1], "minute": 0}},


### PR DESCRIPTION
Every merchant ships with trading hours and the README sells them — a jeweler keeps 09:00–17:00, a fence trades 20:00 to 04:00 — but **nothing ever read them**. All 51 ship `status: "open"`, so the hours were displayed and never evaluated, and every shop stood open around the clock. A fence open at noon is the visible half of that.

### Why Item Piles can't do it

`isMerchantClosed` calls `window.SimpleCalendar.api` four times. Shipping `status: "auto"` instead does not help — when that module is absent, `updateOpenCloseStatus` rewrites the status back to `"open"` and saves it, which is also a write that throws on a locked compendium.

Simple Calendar is unmaintained with no v14 build, and this module requires v14, so that route is **shut for good** rather than merely missing. Calendaria is not a substitute: its only mentions of Simple Calendar are an importer for migrating old configs.

### What this does

Item Piles documents `open` and `closed` as first-class *manual* statuses, so drive those from Foundry's own clock — the same trick the restock pass already plays, reusing the `isOpenAt` it already reads the hours with. No patching, and any calendar that advances world time works.

Verified against Item Piles' own `isMerchantClosed` across all 51 shops at every half hour — **2448 pairs, agreeing everywhere**, including the after-midnight wrap. The fence now reads closed at noon and open at 21:00.

**On by default**, unlike restocking: closing a shop to players is reversible, where a restock discards hand-added stock. Its hook is registered separately for that reason. Only the active GM writes, the status is only written when it changes, and turning the setting off hands every shop back to always-open rather than leaving one shut.

Runtime and docs only — `_source` is untouched. Also corrects the README, which said the closed-day flags "will work if you ever install Simple Calendar". They will not.