### PR TITLE
Rename the drink kind to food-drink

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,13 @@ derived from its own stock list, so a shop can never refuse something it sells.
 
 Item type alone is not enough to tell a galley from a gemstone — dnd5e calls
 both `loot` — so this module's goods each carry a kind (vehicle, mount, tack,
-drink, meal, lodging, service, spellcasting, component, travel) that the filters
-match on.
+food-drink, meal, lodging, service, spellcasting, component, travel) that the
+filters match on.
+
+`food-drink` is a shelf category, not a nutrition one: it covers the five
+physical consumables, bread and cheese included. What Simple Nutrition 5e treats
+as water is decided separately, by item identifier, and only ale and wine are in
+that list.
 
 ## Prices
 

--- a/_source/goods/Ale_mug__5rhgtJzkTCWzRATg.json
+++ b/_source/goods/Ale_mug__5rhgtJzkTCWzRATg.json
@@ -120,7 +120,7 @@
       }
     },
     "merchant-presets": {
-      "kind": "drink"
+      "kind": "food-drink"
     }
   }
 }

--- a/_source/goods/Bread_loaf__bCVz2SKAGws8rCLq.json
+++ b/_source/goods/Bread_loaf__bCVz2SKAGws8rCLq.json
@@ -120,7 +120,7 @@
       }
     },
     "merchant-presets": {
-      "kind": "drink"
+      "kind": "food-drink"
     }
   }
 }

--- a/_source/goods/Cheese_wedge__xjW2wldJb98ggjQR.json
+++ b/_source/goods/Cheese_wedge__xjW2wldJb98ggjQR.json
@@ -120,7 +120,7 @@
       }
     },
     "merchant-presets": {
-      "kind": "drink"
+      "kind": "food-drink"
     }
   }
 }

--- a/_source/goods/Wine_Common_bottle__7SDvqzSyEHkOoFjj.json
+++ b/_source/goods/Wine_Common_bottle__7SDvqzSyEHkOoFjj.json
@@ -120,7 +120,7 @@
       }
     },
     "merchant-presets": {
-      "kind": "drink"
+      "kind": "food-drink"
     }
   }
 }

--- a/_source/goods/Wine_Fine_bottle__AftgNcudTImlyy2Y.json
+++ b/_source/goods/Wine_Fine_bottle__AftgNcudTImlyy2Y.json
@@ -120,7 +120,7 @@
       }
     },
     "merchant-presets": {
-      "kind": "drink"
+      "kind": "food-drink"
     }
   }
 }

--- a/_source/merchants/Adventurers_Store_City_bzURsHrQ4iwtPo4G.json
+++ b/_source/merchants/Adventurers_Store_City_bzURsHrQ4iwtPo4G.json
@@ -4914,7 +4914,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Adventurers_Store_Town_WI49F1bXjoKrBaQg.json
+++ b/_source/merchants/Adventurers_Store_Town_WI49F1bXjoKrBaQg.json
@@ -4400,7 +4400,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Adventurers_Store_Village_8ayCIZ7LmeYubyw4.json
+++ b/_source/merchants/Adventurers_Store_Village_8ayCIZ7LmeYubyw4.json
@@ -3534,7 +3534,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
+++ b/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
@@ -2825,7 +2825,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
+++ b/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
@@ -2485,7 +2485,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Alchemists_Apothecaries_Village_K4sX0S4KIIsXUeTZ.json
+++ b/_source/merchants/Alchemists_Apothecaries_Village_K4sX0S4KIIsXUeTZ.json
@@ -2027,7 +2027,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
+++ b/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
@@ -3906,7 +3906,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
+++ b/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
@@ -3073,7 +3073,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Arcane_Store_Village_BhUHpOxQV6rSkfA4.json
+++ b/_source/merchants/Arcane_Store_Village_BhUHpOxQV6rSkfA4.json
@@ -2468,7 +2468,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Armourer_Blacksmiths_City_PjzhoPPbwfYoLyho.json
+++ b/_source/merchants/Armourer_Blacksmiths_City_PjzhoPPbwfYoLyho.json
@@ -9054,7 +9054,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Armourer_Blacksmiths_Town_vjHTqmO54VdBokKn.json
+++ b/_source/merchants/Armourer_Blacksmiths_Town_vjHTqmO54VdBokKn.json
@@ -8866,7 +8866,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Armourer_Blacksmiths_Village_tr2tgfSP4zq5vXk8.json
+++ b/_source/merchants/Armourer_Blacksmiths_Village_tr2tgfSP4zq5vXk8.json
@@ -6839,7 +6839,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Criminal_Illicit_Store_City_H5hL07qDuFQpaFT9.json
+++ b/_source/merchants/Criminal_Illicit_Store_City_H5hL07qDuFQpaFT9.json
@@ -9327,7 +9327,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.25,

--- a/_source/merchants/Criminal_Illicit_Store_Town_Lur3FQEmjd5pcwPN.json
+++ b/_source/merchants/Criminal_Illicit_Store_Town_Lur3FQEmjd5pcwPN.json
@@ -7605,7 +7605,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.25,

--- a/_source/merchants/Criminal_Illicit_Store_Village_mfHdaPywzU7n0bMd.json
+++ b/_source/merchants/Criminal_Illicit_Store_Village_mfHdaPywzU7n0bMd.json
@@ -4641,7 +4641,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.25,

--- a/_source/merchants/Dock_City_AQvzAugD0mDLKKOn.json
+++ b/_source/merchants/Dock_City_AQvzAugD0mDLKKOn.json
@@ -556,7 +556,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "mount,tack,drink,meal,lodging,service,spellcasting,component"
+            "filters": "mount,tack,food-drink,meal,lodging,service,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Dock_Town_6Ztn4A3Qmw7BqtaA.json
+++ b/_source/merchants/Dock_Town_6Ztn4A3Qmw7BqtaA.json
@@ -376,7 +376,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "mount,tack,drink,meal,lodging,service,spellcasting,component"
+            "filters": "mount,tack,food-drink,meal,lodging,service,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Dock_Village_rZ8AENGyt2zmDGfd.json
+++ b/_source/merchants/Dock_Village_rZ8AENGyt2zmDGfd.json
@@ -256,7 +256,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "mount,tack,drink,meal,lodging,service,spellcasting,component"
+            "filters": "mount,tack,food-drink,meal,lodging,service,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
+++ b/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
@@ -6501,7 +6501,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
+++ b/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
@@ -5940,7 +5940,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Druidic_Store_Village_EN7eh38RFIQeOE1P.json
+++ b/_source/merchants/Druidic_Store_Village_EN7eh38RFIQeOE1P.json
@@ -5354,7 +5354,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Fletcher_Woodworker_City_zlyiXsGcSIYxDJfA.json
+++ b/_source/merchants/Fletcher_Woodworker_City_zlyiXsGcSIYxDJfA.json
@@ -3693,7 +3693,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Fletcher_Woodworker_Town_4ehrvYemvvZQEVf1.json
+++ b/_source/merchants/Fletcher_Woodworker_Town_4ehrvYemvvZQEVf1.json
@@ -3355,7 +3355,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Fletcher_Woodworker_Village_00tdck8znFTmgKym.json
+++ b/_source/merchants/Fletcher_Woodworker_Village_00tdck8znFTmgKym.json
@@ -2926,7 +2926,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/General_Store_City_obRqh3VbEiefEINw.json
+++ b/_source/merchants/General_Store_City_obRqh3VbEiefEINw.json
@@ -7274,7 +7274,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/General_Store_Town_57oHVmTqHdn2T8iW.json
+++ b/_source/merchants/General_Store_Town_57oHVmTqHdn2T8iW.json
@@ -6170,7 +6170,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/General_Store_Village_L6zH6zpoDpLwHcwz.json
+++ b/_source/merchants/General_Store_Village_L6zH6zpoDpLwHcwz.json
@@ -5673,7 +5673,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
+++ b/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
@@ -306,7 +306,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -433,7 +433,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -560,7 +560,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -687,7 +687,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -814,7 +814,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {

--- a/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
+++ b/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
@@ -306,7 +306,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -433,7 +433,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -560,7 +560,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -687,7 +687,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -814,7 +814,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {

--- a/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
+++ b/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
@@ -306,7 +306,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -433,7 +433,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -560,7 +560,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {
@@ -687,7 +687,7 @@
           }
         },
         "merchant-presets": {
-          "kind": "drink"
+          "kind": "food-drink"
         }
       },
       "_stats": {

--- a/_source/merchants/Jeweler_City_e4aPnMG6goFT0zMy.json
+++ b/_source/merchants/Jeweler_City_e4aPnMG6goFT0zMy.json
@@ -737,7 +737,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Jeweler_Town_jwnx9SR2cla6JDNr.json
+++ b/_source/merchants/Jeweler_Town_jwnx9SR2cla6JDNr.json
@@ -618,7 +618,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Jeweler_Village_qvDF1F8ozMgRrsxU.json
+++ b/_source/merchants/Jeweler_Village_qvDF1F8ozMgRrsxU.json
@@ -559,7 +559,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Leatherworker_City_ynVWaEF6RzWJdx78.json
+++ b/_source/merchants/Leatherworker_City_ynVWaEF6RzWJdx78.json
@@ -1827,7 +1827,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Leatherworker_Town_rrXsKno8WincEfQz.json
+++ b/_source/merchants/Leatherworker_Town_rrXsKno8WincEfQz.json
@@ -1735,7 +1735,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Leatherworker_Village_pptkk5NYSf6vOZg0.json
+++ b/_source/merchants/Leatherworker_Village_pptkk5NYSf6vOZg0.json
@@ -1580,7 +1580,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Musical_Store_City_DcfxAJhKMhypgiIL.json
+++ b/_source/merchants/Musical_Store_City_DcfxAJhKMhypgiIL.json
@@ -2316,7 +2316,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Musical_Store_Town_y10ZroQxND6Eq6LS.json
+++ b/_source/merchants/Musical_Store_Town_y10ZroQxND6Eq6LS.json
@@ -2098,7 +2098,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Musical_Store_Village_0oaW05C0ZXUwucp5.json
+++ b/_source/merchants/Musical_Store_Village_0oaW05C0ZXUwucp5.json
@@ -1602,7 +1602,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
+++ b/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
@@ -1333,7 +1333,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "drink,meal,lodging,spellcasting,component"
+            "filters": "food-drink,meal,lodging,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
+++ b/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
@@ -1034,7 +1034,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "drink,meal,lodging,spellcasting,component"
+            "filters": "food-drink,meal,lodging,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
+++ b/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
@@ -974,7 +974,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "drink,meal,lodging,spellcasting,component"
+            "filters": "food-drink,meal,lodging,spellcasting,component"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tailor_Textile_Store_City_fWpfjHUwCxMUHWhm.json
+++ b/_source/merchants/Tailor_Textile_Store_City_fWpfjHUwCxMUHWhm.json
@@ -1522,7 +1522,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tailor_Textile_Store_Town_QD6M8RWl2t1vY5bR.json
+++ b/_source/merchants/Tailor_Textile_Store_Town_QD6M8RWl2t1vY5bR.json
@@ -1304,7 +1304,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tailor_Textile_Store_Village_mAoxOdpA6pn04CGc.json
+++ b/_source/merchants/Tailor_Textile_Store_Village_mAoxOdpA6pn04CGc.json
@@ -1108,7 +1108,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
+++ b/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
@@ -3823,7 +3823,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
+++ b/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
@@ -3390,7 +3390,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
+++ b/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
@@ -2438,7 +2438,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
+++ b/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
@@ -4629,7 +4629,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tinkering_Store_Town_IZ2qsuJc4ynG0OMI.json
+++ b/_source/merchants/Tinkering_Store_Town_IZ2qsuJc4ynG0OMI.json
@@ -4376,7 +4376,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/_source/merchants/Tinkering_Store_Village_mdqxFzOKITaPFR3Q.json
+++ b/_source/merchants/Tinkering_Store_Village_mdqxFzOKITaPFR3Q.json
@@ -3230,7 +3230,7 @@
           },
           {
             "path": "flags.merchant-presets.kind",
-            "filters": "vehicle,mount,tack,drink,meal,lodging,service,spellcasting,component,travel"
+            "filters": "vehicle,mount,tack,food-drink,meal,lodging,service,spellcasting,component,travel"
           }
         ],
         "buyPriceModifier": 1.0,

--- a/tools/build_srd.py
+++ b/tools/build_srd.py
@@ -81,7 +81,7 @@ SRD_SOURCE = {"book": "SRD 5.2", "license": "CC-BY-4.0", "rules": "2024", "revis
 # not take a galley. Note this REPLACES the global filter list rather than
 # adding to it, so the dnd5e defaults have to be carried along.
 PHYSICAL_TYPES = ["weapon", "equipment", "consumable", "tool", "loot", "container"]
-GOODS_KINDS = ["vehicle", "mount", "tack", "drink", "meal", "lodging",
+GOODS_KINDS = ["vehicle", "mount", "tack", "food-drink", "meal", "lodging",
                "service", "spellcasting", "component", "travel"]
 DND5E_ITEM_FILTERS = [
     {"path": "type", "filters": "background,class,facility,feat,race,spell,subclass"},


### PR DESCRIPTION
A loaf of bread carrying `kind: "drink"` reads as a bug. It is not one — `kind` drives only the shop refuse-filter, and what Simple Nutrition 5e counts as water is decided separately, **by item identifier**, where only ale and the two wines appear. But the label invites exactly the wrong reading, and it cost a question to resolve.

The kind covers the five physical consumables — ale, bread, cheese and two wines — as against the six abstract *Meal* entries, and maps to the Food & Drink compendium folder. So name it for what it is.

**No behaviour changes.** Merchants already in a world keep the old kind on both their goods and their filters, so they stay self-consistent; only fresh drags use the new one.

> Regenerates `_source/merchants`, so this and #2 will conflict on 49 files. Not textually resolvable — whichever lands second gets rebased and the generator re-run.