### PR TITLE
Gate releases on CI, and keep main's version honest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # Called by the release workflow so a tag cannot publish without the same
+  # validation a pull request gets, run against the tagged tree.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,11 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    uses: ./.github/workflows/ci.yml
+
   release:
+    needs: validate
     runs-on: ubuntu-latest
     env:
       FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
@@ -68,14 +72,17 @@ jobs:
           {
             echo "## What's changed"
             echo ""
-            # Commit subjects since the previous tag, skipping commits that
-            # only touch CI/workflow files — players don't care about those.
+            # Commit subjects since the previous tag, skipping merge commits
+            # and commits that only touch CI/workflow files — players care
+            # about neither. Without --no-merges a release batching several
+            # pull requests lists some of them twice: once as the change and
+            # once as "Merge pull request #N from ...".
             if [ -n "$PREV" ]; then
               RANGE="$PREV..${GITHUB_REF_NAME}"
             else
               RANGE="${GITHUB_REF_NAME}"
             fi
-            git log --pretty='- %s' "$RANGE" -- . ':!.github'
+            git log --no-merges --pretty='- %s' "$RANGE" -- . ':!.github'
             echo ""
             if [ -n "$PREV" ]; then
               echo "**Full changelog:** [\`$PREV...${GITHUB_REF_NAME}\`](https://github.com/${GITHUB_REPOSITORY}/compare/$PREV...${GITHUB_REF_NAME})"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,15 +85,34 @@ Four constraints worth knowing before changing the generator:
   paid-content check.
 - One logical change per PR, with a subject line that would read well in release
   notes — commit subjects become release-note bullets.
-- Don't bump `version` in `module.json`; the maintainer versions and tags
-  releases.
+- Don't bump `version` in `module.json`. Between releases it carries the *next*
+  version with a `-dev` suffix (e.g. `1.1.0-dev`); the maintainer sets the real
+  version when tagging.
 
 ## Releases (maintainer)
 
-Bump `version` in `module.json`, commit, tag `vX.Y.Z`, push the tag. CI compiles
-the packs, builds the zip (excluding `_source`, `tools` and the npm files),
-publishes the GitHub release, and registers the version with the Foundry package
-registry if `FOUNDRY_RELEASE_TOKEN` is set.
+`main` is the only long-lived branch, and it carries unreleased work. There is
+no separate development branch, because what has been published is recorded by
+tags rather than by a branch: releases are cut from `vX.Y.Z` tags, and installs
+resolve a release asset, never a branch. `git log vX.Y.Z..main` is the
+unreleased set, and several merged pull requests routinely go out in one
+release.
+
+To cut one:
+
+1. Set `version` in `module.json` to the plain release version (drop the `-dev`
+   suffix), commit, tag `vX.Y.Z`, push the tag.
+2. Bump `version` to the next `-dev` (e.g. `1.2.0-dev`) and commit, so a clone
+   of `main` never reports itself as the released version — issue triage labels
+   a report `outdated` by comparing the version it names against the latest
+   release.
+
+Pushing the tag runs the CI validation against the tagged tree first; a release
+is only built if that passes. The release job then compiles the packs, builds
+the zip (excluding `_source`, `tools` and the npm files), publishes the GitHub
+release with notes drawn from the commit subjects since the previous tag, and
+registers the version with the Foundry package registry if
+`FOUNDRY_RELEASE_TOKEN` is set.
 
 ### Prereleases
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "compatibility": {
     "minimum": "14",
     "verified": "14"


### PR DESCRIPTION
Three loose ends in the release path, none of which needed a
development branch to fix.

Tag pushes ran the release workflow alone, so a tag could publish
without the manifest validation and paid-content check a pull request
gets. CI is now callable, and the release job waits on it, run against
the tagged tree.

Release notes batching several pull requests listed some of them twice,
once as the change and once as "Merge pull request #N from ...", because
path-limited history simplification drops only some merge commits.
--no-merges drops all of them.

Between releases module.json named the version already published, so a
clone of main reported itself as the released version and issue triage
could not tell the two apart. Main now carries the next version with a
-dev suffix.