### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14"


### PR DESCRIPTION
Sets `module.json` to `1.1.0` for the release. After merge, `main` is tagged `v1.1.0` and then bumped to `1.2.0-dev`.

## Shipping since v1.0.0
- Open and close the shops on the world clock
- Add an opt-in setting to keep shop stock off the shopkeeper
- Stat the merchants from SRD 5.2 actor blocks, sourcing features and gear from the SRD packs
- Rename the drink kind to food-drink
- Stop load_srd indexing the equipment pack's folders
- README cleanup and status badges; releases now gated on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)