### PR TITLE
Bump main to 1.2.0-dev after the v1.1.0 release

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.1.0",
+  "version": "1.2.0-dev",
   "compatibility": {
     "minimum": "14",
     "verified": "14"


### PR DESCRIPTION
Step 2 of the release procedure in CONTRIBUTING.md: main carries the next version with a -dev suffix so a clone never reports itself as the released v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)