### PR TITLE
Offer to eat a meal the moment it is bought

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           done < <(find scripts -name '*.mjs' -print0)
           exit "$status"
 
+      - name: Unit tests
+        run: npm test
+
       - name: Validate module.json
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ With the *Ale and wine slake thirst* setting on, ale and wine count towards
 water instead — that module treats an item as food or water, never both. One
 drink is a pint; a Medium creature needs a gallon a day.
 
+Meals are services — you eat at the inn's table, and nothing goes in the pack —
+so with the *Meals feed the buyer* setting on, buying one asks the buyer whether
+to eat it there and then, and credits today's food and drink by quality: a
+squalid meal is a quarter of a Medium creature's day with nothing to drink, a
+modest one a full day's food and a pint, a wealthy one two days' food and half a
+gallon, an aristocratic one a feast — four days' food and a gallon — enough to
+feed a Large character in one sitting. Simple Nutrition resets the tally every
+long rest, so surplus is flavour rather than stockpiling.
+
 ## How stock behaves
 
 - **Finite (default)** — the packs ship a rolled stock snapshot, so a merchant

--- a/_source/goods/Meal_Aristocratic_aukcsdXdSNHJlZR7.json
+++ b/_source/goods/Meal_Aristocratic_aukcsdXdSNHJlZR7.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 4,
+        "water": 1
+      }
     }
   }
 }

--- a/_source/goods/Meal_Comfortable_OwxKx2vQ28EaBXMP.json
+++ b/_source/goods/Meal_Comfortable_OwxKx2vQ28EaBXMP.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 1,
+        "water": 0.25
+      }
     }
   }
 }

--- a/_source/goods/Meal_Modest_T2GQ63oNssZ08DmY.json
+++ b/_source/goods/Meal_Modest_T2GQ63oNssZ08DmY.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 1,
+        "water": 0.125
+      }
     }
   }
 }

--- a/_source/goods/Meal_Poor_jWHa0tpy76NkMDLL.json
+++ b/_source/goods/Meal_Poor_jWHa0tpy76NkMDLL.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 0.5,
+        "water": 0.125
+      }
     }
   }
 }

--- a/_source/goods/Meal_Squalid_AaXsydDkadKI8bkQ.json
+++ b/_source/goods/Meal_Squalid_AaXsydDkadKI8bkQ.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 0.25,
+        "water": 0
+      }
     }
   }
 }

--- a/_source/goods/Meal_Wealthy_yjhtFu0pXUUpv4ZZ.json
+++ b/_source/goods/Meal_Wealthy_yjhtFu0pXUUpv4ZZ.json
@@ -47,7 +47,11 @@
       }
     },
     "merchant-presets": {
-      "kind": "meal"
+      "kind": "meal",
+      "nutrition": {
+        "food": 2,
+        "water": 0.5
+      }
     }
   }
 }

--- a/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
+++ b/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
@@ -1706,7 +1706,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.25,
+            "water": 0
+          }
         }
       },
       "_stats": {
@@ -1760,7 +1764,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.5,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1814,7 +1822,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1868,7 +1880,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.25
+          }
         }
       },
       "_stats": {
@@ -1922,7 +1938,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 2,
+            "water": 0.5
+          }
         }
       },
       "_stats": {
@@ -1976,7 +1996,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 4,
+            "water": 1
+          }
         }
       },
       "_stats": {

--- a/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
+++ b/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
@@ -1649,7 +1649,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.25,
+            "water": 0
+          }
         }
       },
       "_stats": {
@@ -1703,7 +1707,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.5,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1757,7 +1765,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1811,7 +1823,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.25
+          }
         }
       },
       "_stats": {
@@ -1865,7 +1881,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 2,
+            "water": 0.5
+          }
         }
       },
       "_stats": {

--- a/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
+++ b/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
@@ -1468,7 +1468,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.25,
+            "water": 0
+          }
         }
       },
       "_stats": {
@@ -1522,7 +1526,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 0.5,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1576,7 +1584,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.125
+          }
         }
       },
       "_stats": {
@@ -1630,7 +1642,11 @@
           }
         },
         "merchant-presets": {
-          "kind": "meal"
+          "kind": "meal",
+          "nutrition": {
+            "food": 1,
+            "water": 0.25
+          }
         }
       },
       "_stats": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "description": "Build tooling for the Merchant Presets Foundry VTT module",
   "scripts": {
+    "test": "node --test 'tools/*.test.mjs'",
     "pack": "npm run pack:merchants && npm run pack:stock && npm run pack:goods",
     "pack:merchants": "fvtt package pack -n merchants --id merchant-presets --type Module --in _source/merchants --out packs",
     "pack:stock": "fvtt package pack -n stock --id merchant-presets --type Module --in _source/stock --out packs",

--- a/scripts/merchant-presets.mjs
+++ b/scripts/merchant-presets.mjs
@@ -18,6 +18,8 @@
  *    settlement size, so two copies of the same shop differ.
  */
 
+import { applyMeal } from "./nutrition.mjs";
+
 const MODULE = "merchant-presets";
 const STOCK_PREFIX = `Compendium.${MODULE}.stock.RollTable.`;
 const TABLE_FOLDER = "Merchant Stock";
@@ -600,6 +602,90 @@ async function registerDrinks() {
   }
 }
 
+/* -------------------------------------------------------------------- meals */
+
+/**
+ * Offer to eat a meal the moment it is bought.
+ *
+ * Meals are Item Piles services: paying for one hands nothing over, because
+ * the eating happens at the inn's table. Simple Nutrition 5e can only feed a
+ * character from an item in their inventory, so without this the meal would
+ * be money for nothing. Instead, when a preset merchant sells a good carrying
+ * a `nutrition` flag, the buyer is asked whether to eat it now, and saying
+ * yes credits today's food and water the way that module's own Eat dialog
+ * would (see scripts/nutrition.mjs for the arithmetic, and the imports below
+ * for its state helpers and condition ids). The flag is the whole contract, so
+ * a meal copied onto a tavern of your own works the same way.
+ *
+ * Item Piles fires `item-piles-tradeItems` on every client; only the buying
+ * user's client acts, so one purchase gets one prompt. Players own their own
+ * characters, so the flag write and the condition toggle need no GM.
+ */
+async function offerMeals(_sellerUuid, buyerUuid, itemPrices, userId) {
+  if (userId !== game.user.id) return;
+  if (!game.modules.get(NUTRITION_MODULE)?.active) return;
+  if (!game.settings.get(MODULE, "mealsFeed")) return;
+  const buyer = await fromUuid(buyerUuid);
+  if (buyer?.type !== "character") return;
+
+  const meals = (itemPrices?.buyerReceive ?? []).filter(e =>
+    e.quantity > 0 && e.item?.getFlag?.(MODULE, "nutrition"));
+  for (const entry of meals) {
+    await eatMeal(buyer, entry.item, entry.quantity)
+      .catch(err => console.error(`${MODULE} | could not apply ${entry.item.name}`, err));
+  }
+}
+
+async function eatMeal(actor, item, quantity) {
+  const base = `modules/${NUTRITION_MODULE}/scripts`;
+  const [cfg, sn] = await Promise.all([
+    import(foundry.utils.getRoute(`${base}/config.mjs`)),
+    import(foundry.utils.getRoute(`${base}/nutrition/actor.mjs`))
+  ]);
+  for (const fn of ["getNutritionState", "setNutritionState", "getNutritionNeeds", "formatNutritionAmount"]) {
+    if (typeof sn[fn] !== "function") throw new Error(`Simple Nutrition no longer exports ${fn}`);
+  }
+
+  const nutrition = item.getFlag(MODULE, "nutrition");
+  const needs = sn.getNutritionNeeds(actor);
+  const food = nutrition.food * quantity;
+  const water = nutrition.water * quantity;
+  const parts = [];
+  if (food) parts.push(`Food ${sn.formatNutritionAmount("food", food)}${food >= needs.food ? " (a full day)" : ""}`);
+  if (water) parts.push(`Drink ${sn.formatNutritionAmount("water", water)}${water >= needs.water ? " (a full day)" : ""}`);
+  const label = quantity > 1 ? `${quantity} × ${item.name}` : item.name;
+
+  const eat = await foundry.applications.api.DialogV2.confirm({
+    window: { title: "Eat now?" },
+    content: `<p>${actor.name} bought <strong>${label}</strong>. Eat it here?</p><p>${parts.join(" · ")}</p>`,
+    yes: { label: "Eat", icon: "fa-solid fa-utensils" },
+    no: { label: "Not now" },
+    rejectClose: false
+  });
+  if (!eat) return;
+
+  const has = {
+    malnourished: actor.hasConditionEffect(cfg.CONDITION_EFFECT_MALNOURISHED),
+    dehydrated: actor.hasConditionEffect(cfg.CONDITION_EFFECT_DEHYDRATED)
+  };
+  const result = applyMeal(sn.getNutritionState(actor), needs, nutrition, quantity, has);
+  await sn.setNutritionState(actor, result.state);
+  if (result.clearMalnutrition) await actor.toggleStatusEffect(cfg.CONDITION_MALNUTRITION, { active: false });
+  if (result.clearDehydration) await actor.toggleStatusEffect(cfg.CONDITION_DEHYDRATION, { active: false });
+
+  await ChatMessage.create({
+    speaker: ChatMessage.getSpeaker({ actor }),
+    content: `<p><strong>${actor.name}</strong> eats: ${label}.</p><p>${parts.join(" · ")}</p>`
+  });
+  log(`${actor.name} ate ${label}: food ${result.state.food}, water ${result.state.water}`);
+}
+
+function registerMeals() {
+  Hooks.on("item-piles-tradeItems", (...args) => {
+    offerMeals(...args).catch(err => console.error(`${MODULE} |`, err));
+  });
+}
+
 /* ----------------------------------------------------------------- settings */
 
 Hooks.once("init", () => {
@@ -693,6 +779,19 @@ Hooks.once("init", () => {
     type: Boolean,
     default: true
   });
+
+  game.settings.register(MODULE, "mealsFeed", {
+    name: "Meals feed the buyer",
+    hint: "With Simple Nutrition 5e installed, buying a meal at an inn asks the buyer whether to "
+      + "eat it there and then, and credits today's food and drink by the meal's quality — a "
+      + "squalid meal is a quarter of a Medium creature's day with nothing to drink, a modest one "
+      + "a full day's food and a pint, an aristocratic one a feast. Meals are services, so no item "
+      + "changes hands either way.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
+  });
 });
 
 Hooks.once("ready", () => {
@@ -703,6 +802,8 @@ Hooks.once("ready", () => {
   // Every client evaluates its own nutrition candidates, so this must run for
   // players too — and it does not depend on Item Piles.
   registerDrinks();
+  // The buyer's own client answers the meal prompt, so this is for players too.
+  registerMeals();
 
   if (!game.user.isGM) return;
   if (!game.modules.get("item-piles")?.active) {

--- a/scripts/nutrition.mjs
+++ b/scripts/nutrition.mjs
@@ -1,0 +1,36 @@
+/**
+ * The arithmetic of eating a meal, kept free of Foundry so it can be tested
+ * with plain Node (tools/nutrition.test.mjs).
+ *
+ * This mirrors what Simple Nutrition 5e does when its own Eat dialog consumes
+ * an item (scripts/nutrition/hooks.mjs, consumeNutrition): add the amount to
+ * today's tally, and if that tally now meets the day's need while the actor is
+ * carrying the matching condition, clear it and remember having done so. Both
+ * tallies reset to zero at the next long rest, so nothing carries over.
+ *
+ * @param {object} state      Simple Nutrition's state for the actor: food, water,
+ *                            starvation, foodConditionRemoved, waterConditionRemoved.
+ * @param {object} needs      The actor's daily need: { food (lb), water (gallons) }.
+ * @param {object} nutrition  What one meal provides: { food (lb), water (gallons) }.
+ * @param {number} quantity   How many were bought.
+ * @param {object} has        Which conditions the actor currently carries:
+ *                            { malnourished, dehydrated }.
+ * @returns {{ state: object, clearMalnutrition: boolean, clearDehydration: boolean }}
+ */
+export function applyMeal(state, needs, nutrition, quantity, has) {
+  const food = (state.food ?? 0) + (nutrition.food ?? 0) * quantity;
+  const water = (state.water ?? 0) + (nutrition.water ?? 0) * quantity;
+  const clearMalnutrition = !!has.malnourished && food >= needs.food;
+  const clearDehydration = !!has.dehydrated && water >= needs.water;
+  return {
+    state: {
+      ...state,
+      food,
+      water,
+      foodConditionRemoved: !!state.foodConditionRemoved || clearMalnutrition,
+      waterConditionRemoved: !!state.waterConditionRemoved || clearDehydration
+    },
+    clearMalnutrition,
+    clearDehydration
+  };
+}

--- a/tools/nutrition.test.mjs
+++ b/tools/nutrition.test.mjs
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyMeal } from "../scripts/nutrition.mjs";
+
+const needs = { food: 1, water: 1 };          // a Medium creature's day
+const modest = { food: 1, water: 0.125 };
+const squalid = { food: 0.25, water: 0 };
+
+test("adds the meal's food and water to today's tally", () => {
+  const r = applyMeal({ food: 0.5, water: 0.25 }, needs, modest, 1, {});
+  assert.equal(r.state.food, 1.5);
+  assert.equal(r.state.water, 0.375);
+});
+
+test("quantity multiplies", () => {
+  const r = applyMeal({ food: 0, water: 0 }, needs, squalid, 4, {});
+  assert.equal(r.state.food, 1);
+});
+
+test("clears malnutrition only once the day's food need is met, and records it", () => {
+  const short = applyMeal({ food: 0, water: 0 }, needs, squalid, 1, { malnourished: true });
+  assert.equal(short.clearMalnutrition, false);
+  assert.equal(short.state.foodConditionRemoved, false);
+  const full = applyMeal({ food: 0, water: 0 }, needs, modest, 1, { malnourished: true });
+  assert.equal(full.clearMalnutrition, true);
+  assert.equal(full.state.foodConditionRemoved, true);
+});
+
+test("clears dehydration the same way, independently", () => {
+  const r = applyMeal({ food: 0, water: 0.875 }, needs, modest, 1, { dehydrated: true });
+  assert.equal(r.clearDehydration, true);
+  assert.equal(r.state.waterConditionRemoved, true);
+  assert.equal(r.clearMalnutrition, false);
+});
+
+test("never clears a condition the actor does not have, and keeps an earlier marker", () => {
+  const r = applyMeal({ food: 0, water: 0, foodConditionRemoved: true }, needs, modest, 1, {});
+  assert.equal(r.clearMalnutrition, false);
+  assert.equal(r.state.foodConditionRemoved, true);
+});
+
+test("untouched state fields survive", () => {
+  const r = applyMeal({ food: 0, water: 0, starvation: 3 }, needs, modest, 1, {});
+  assert.equal(r.state.starvation, 3);
+});


### PR DESCRIPTION
The six Meal goods are Item Piles **services** — you eat at the inn's table, nothing goes in the pack — which meant Simple Nutrition 5e never saw them (it only feeds from a weighted `consumable`/`food` item in inventory). Making them items would be wrong twice over: a meal isn't carried, and Simple Nutrition resets food and water at every long rest, so a meal can only ever cover *today*.

**What this does**
- Each Meal good carries `flags.merchant-presets.nutrition = { food (lb), water (gal) }` by quality; the generator copies it into the three Inns. Squalid ¼ lb / no drink → Modest 1 lb + 1 pint (a Medium PC's full day of food) → Aristocratic 4 lb + 1 gal (feeds a Large PC in one sitting).
- On purchase, Item Piles' `item-piles-tradeItems` hook — which still lists services in `buyerReceive` — raises an **Eat now?** dialog on the buyer's own client. Yes credits today's tally exactly as Simple Nutrition's own Eat dialog does (add the amounts; clear Malnutrition/Dehydration if the day's need is now met and record it), reusing that module's own state/needs helpers and condition ids via dynamic import, the same pattern as `registerDrinks`.
- Pure arithmetic in `scripts/nutrition.mjs` with a Node test (`npm test`, now a CI step).
- World setting *Meals feed the buyer*, on by default; inert without Simple Nutrition.

**Verified**: generator reproduces the flag propagation (only the 3 Inn merchants change; stock and every other merchant byte-identical), `npm test` 6/6, packs build, paid-content grep clean. In-world smoke test (buy a meal at an Inn with Simple Nutrition active) still to do.

Not a release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)