### PR TITLE
Put a bought animal in the world

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,12 @@ Four constraints worth knowing before changing the generator:
   `scripts/merchant-presets.mjs` skip it via `isGear`. Gear is appended *after*
   the item filters are computed — inside the loop its own types would otherwise
   read as stocked and let a chain shirt onto the shelf.
+- **Goods can carry behaviour flags** that the runtime acts on at purchase, via
+  Item Piles' `tradeItems` hook: `flags.merchant-presets.actor` names the SRD
+  stat block an animal good stands for, and buying it copies that actor into the
+  world. The generator copies the whole goods document onto each merchant, so a
+  flag set in `_source/goods` needs a regeneration to reach the shops that sell
+  it.
 - **Containers** cannot carry a quantity: dnd5e declares
   `quantity: new NumberField({min: 1, max: 1})`, because each container is a
   distinct object with its own contents. A shop with four pouches holds four

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Prices and weights are the SRD's, verified line by line against those tables, so
 50 of them are marked `SRD 5.2 · CC-BY-4.0` even though this module authors the
 item document — the content is the SRD's, and CC-BY asks to be told so.
 
+The eight animals are the one place the SRD does publish the thing itself — as a
+stat block in the system's own SRD actor compendium, not as an item. So with the
+*Bought animals are added to the world* setting on (it is by default), buying a
+riding horse copies the SRD Riding Horse into the world as an actor in a
+*Purchased Animals* folder, owned by whoever owns the buying character, and the
+item in their pack becomes the bill of sale, linking to the creature. Nothing is
+placed on a scene; the GM drags it in from the sidebar. Selling the deed back to
+a stable is money only — the animal stays for the GM to remove or keep.
+
 Six carry no source at all, being neither in the SRD nor in the 2024 rules: the
 two coach rides and the road toll, carried over from the 2014 *Services* table
 because the shop guide sells them, and the three spell-component price bands.

--- a/_source/goods/Camel_QIKX4JCTF5WLCoFq.json
+++ b/_source/goods/Camel_QIKX4JCTF5WLCoFq.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A desert beast of burden.</p>",
+      "value": "<p>A desert beast of burden.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmCamel000000000]{Camel}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmCamel000000000"
     }
   }
 }

--- a/_source/goods/Elephant_s3qNp7Lo4mQpfo7K.json
+++ b/_source/goods/Elephant_s3qNp7Lo4mQpfo7K.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A great tusked beast of burden.</p>",
+      "value": "<p>A great tusked beast of burden.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmElephant000000]{Elephant}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmElephant000000"
     }
   }
 }

--- a/_source/goods/Horse_Draft_zIkxXwxhZl5POdri.json
+++ b/_source/goods/Horse_Draft_zIkxXwxhZl5POdri.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A heavy horse bred for hauling.</p>",
+      "value": "<p>A heavy horse bred for hauling.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmDraftHorse0000]{Draft Horse}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmDraftHorse0000"
     }
   }
 }

--- a/_source/goods/Horse_Riding_egOdzurWnblkl5Y0.json
+++ b/_source/goods/Horse_Riding_egOdzurWnblkl5Y0.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A saddle horse.</p>",
+      "value": "<p>A saddle horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmRidingHorse000]{Riding Horse}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmRidingHorse000"
     }
   }
 }

--- a/_source/goods/Mastiff_CLGOx3NIv7ONKGSm.json
+++ b/_source/goods/Mastiff_CLGOx3NIv7ONKGSm.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A large guard and hunting dog.</p>",
+      "value": "<p>A large guard and hunting dog.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMastiff0000000]{Mastiff}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmMastiff0000000"
     }
   }
 }

--- a/_source/goods/Mule_NBSkiyXIeQYgBbWD.json
+++ b/_source/goods/Mule_NBSkiyXIeQYgBbWD.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A sure-footed pack animal.</p>",
+      "value": "<p>A sure-footed pack animal.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMule0000000000]{Mule}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmMule0000000000"
     }
   }
 }

--- a/_source/goods/Pony_0AvDPhxs289znYZH.json
+++ b/_source/goods/Pony_0AvDPhxs289znYZH.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A small riding horse.</p>",
+      "value": "<p>A small riding horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmPony0000000000]{Pony}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmPony0000000000"
     }
   }
 }

--- a/_source/goods/Warhorse_tOGdOLsaBVeiR1Js.json
+++ b/_source/goods/Warhorse_tOGdOLsaBVeiR1Js.json
@@ -8,7 +8,7 @@
   "sort": 0,
   "system": {
     "description": {
-      "value": "<p>A destrier trained for battle.</p>",
+      "value": "<p>A destrier trained for battle.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmWarhorse000000]{Warhorse}</p>",
       "chat": ""
     },
     "quantity": 1,
@@ -47,7 +47,8 @@
       }
     },
     "merchant-presets": {
-      "kind": "mount"
+      "kind": "mount",
+      "actor": "Compendium.dnd5e.actors24.Actor.mmWarhorse000000"
     }
   }
 }

--- a/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
+++ b/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
@@ -1098,7 +1098,7 @@
       "img": "icons/commodities/treasure/figurine-camel.webp",
       "system": {
         "description": {
-          "value": "<p>A desert beast of burden.</p>",
+          "value": "<p>A desert beast of burden.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmCamel000000000]{Camel}</p>",
           "chat": ""
         },
         "quantity": 6,
@@ -1137,7 +1137,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmCamel000000000"
         }
       },
       "_stats": {
@@ -1152,7 +1153,7 @@
       "img": "icons/creatures/mammals/ox-buffalo-horned-green.webp",
       "system": {
         "description": {
-          "value": "<p>A great tusked beast of burden.</p>",
+          "value": "<p>A great tusked beast of burden.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmElephant000000]{Elephant}</p>",
           "chat": ""
         },
         "quantity": 5,
@@ -1191,7 +1192,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmElephant000000"
         }
       },
       "_stats": {
@@ -1206,7 +1208,7 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<p>A heavy horse bred for hauling.</p>",
+          "value": "<p>A heavy horse bred for hauling.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmDraftHorse0000]{Draft Horse}</p>",
           "chat": ""
         },
         "quantity": 3,
@@ -1245,7 +1247,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmDraftHorse0000"
         }
       },
       "_stats": {
@@ -1260,7 +1263,7 @@
       "img": "icons/creatures/mammals/deer-antlers-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A saddle horse.</p>",
+          "value": "<p>A saddle horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmRidingHorse000]{Riding Horse}</p>",
           "chat": ""
         },
         "quantity": 5,
@@ -1299,7 +1302,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmRidingHorse000"
         }
       },
       "_stats": {
@@ -1314,7 +1318,7 @@
       "img": "icons/creatures/mammals/dog-husky-white-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A large guard and hunting dog.</p>",
+          "value": "<p>A large guard and hunting dog.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMastiff0000000]{Mastiff}</p>",
           "chat": ""
         },
         "quantity": 10,
@@ -1353,7 +1357,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMastiff0000000"
         }
       },
       "_stats": {
@@ -1368,7 +1373,7 @@
       "img": "icons/creatures/mammals/livestock-sheep-green.webp",
       "system": {
         "description": {
-          "value": "<p>A sure-footed pack animal.</p>",
+          "value": "<p>A sure-footed pack animal.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMule0000000000]{Mule}</p>",
           "chat": ""
         },
         "quantity": 22,
@@ -1407,7 +1412,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMule0000000000"
         }
       },
       "_stats": {
@@ -1422,7 +1428,7 @@
       "img": "icons/creatures/mammals/deer-antlers-green.webp",
       "system": {
         "description": {
-          "value": "<p>A small riding horse.</p>",
+          "value": "<p>A small riding horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmPony0000000000]{Pony}</p>",
           "chat": ""
         },
         "quantity": 9,
@@ -1461,7 +1467,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmPony0000000000"
         }
       },
       "_stats": {
@@ -1476,7 +1483,7 @@
       "img": "icons/creatures/mammals/unicorn-horned-white.webp",
       "system": {
         "description": {
-          "value": "<p>A destrier trained for battle.</p>",
+          "value": "<p>A destrier trained for battle.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmWarhorse000000]{Warhorse}</p>",
           "chat": ""
         },
         "quantity": 1,
@@ -1515,7 +1522,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmWarhorse000000"
         }
       },
       "_stats": {

--- a/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
+++ b/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
@@ -990,7 +990,7 @@
       "img": "icons/commodities/treasure/figurine-camel.webp",
       "system": {
         "description": {
-          "value": "<p>A desert beast of burden.</p>",
+          "value": "<p>A desert beast of burden.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmCamel000000000]{Camel}</p>",
           "chat": ""
         },
         "quantity": 4,
@@ -1029,7 +1029,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmCamel000000000"
         }
       },
       "_stats": {
@@ -1044,7 +1045,7 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<p>A heavy horse bred for hauling.</p>",
+          "value": "<p>A heavy horse bred for hauling.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmDraftHorse0000]{Draft Horse}</p>",
           "chat": ""
         },
         "quantity": 3,
@@ -1083,7 +1084,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmDraftHorse0000"
         }
       },
       "_stats": {
@@ -1098,7 +1100,7 @@
       "img": "icons/creatures/mammals/deer-antlers-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A saddle horse.</p>",
+          "value": "<p>A saddle horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmRidingHorse000]{Riding Horse}</p>",
           "chat": ""
         },
         "quantity": 3,
@@ -1137,7 +1139,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmRidingHorse000"
         }
       },
       "_stats": {
@@ -1152,7 +1155,7 @@
       "img": "icons/creatures/mammals/dog-husky-white-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A large guard and hunting dog.</p>",
+          "value": "<p>A large guard and hunting dog.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMastiff0000000]{Mastiff}</p>",
           "chat": ""
         },
         "quantity": 4,
@@ -1191,7 +1194,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMastiff0000000"
         }
       },
       "_stats": {
@@ -1206,7 +1210,7 @@
       "img": "icons/creatures/mammals/livestock-sheep-green.webp",
       "system": {
         "description": {
-          "value": "<p>A sure-footed pack animal.</p>",
+          "value": "<p>A sure-footed pack animal.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMule0000000000]{Mule}</p>",
           "chat": ""
         },
         "quantity": 15,
@@ -1245,7 +1249,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMule0000000000"
         }
       },
       "_stats": {
@@ -1260,7 +1265,7 @@
       "img": "icons/creatures/mammals/deer-antlers-green.webp",
       "system": {
         "description": {
-          "value": "<p>A small riding horse.</p>",
+          "value": "<p>A small riding horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmPony0000000000]{Pony}</p>",
           "chat": ""
         },
         "quantity": 6,
@@ -1299,7 +1304,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmPony0000000000"
         }
       },
       "_stats": {

--- a/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
+++ b/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
@@ -987,7 +987,7 @@
       "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
       "system": {
         "description": {
-          "value": "<p>A heavy horse bred for hauling.</p>",
+          "value": "<p>A heavy horse bred for hauling.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmDraftHorse0000]{Draft Horse}</p>",
           "chat": ""
         },
         "quantity": 1,
@@ -1026,7 +1026,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmDraftHorse0000"
         }
       },
       "_stats": {
@@ -1041,7 +1042,7 @@
       "img": "icons/creatures/mammals/deer-antlers-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A saddle horse.</p>",
+          "value": "<p>A saddle horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmRidingHorse000]{Riding Horse}</p>",
           "chat": ""
         },
         "quantity": 1,
@@ -1080,7 +1081,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmRidingHorse000"
         }
       },
       "_stats": {
@@ -1095,7 +1097,7 @@
       "img": "icons/creatures/mammals/dog-husky-white-blue.webp",
       "system": {
         "description": {
-          "value": "<p>A large guard and hunting dog.</p>",
+          "value": "<p>A large guard and hunting dog.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMastiff0000000]{Mastiff}</p>",
           "chat": ""
         },
         "quantity": 3,
@@ -1134,7 +1136,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMastiff0000000"
         }
       },
       "_stats": {
@@ -1149,7 +1152,7 @@
       "img": "icons/creatures/mammals/livestock-sheep-green.webp",
       "system": {
         "description": {
-          "value": "<p>A sure-footed pack animal.</p>",
+          "value": "<p>A sure-footed pack animal.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmMule0000000000]{Mule}</p>",
           "chat": ""
         },
         "quantity": 5,
@@ -1188,7 +1191,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmMule0000000000"
         }
       },
       "_stats": {
@@ -1203,7 +1207,7 @@
       "img": "icons/creatures/mammals/deer-antlers-green.webp",
       "system": {
         "description": {
-          "value": "<p>A small riding horse.</p>",
+          "value": "<p>A small riding horse.</p><p>Stat block: @UUID[Compendium.dnd5e.actors24.Actor.mmPony0000000000]{Pony}</p>",
           "chat": ""
         },
         "quantity": 4,
@@ -1242,7 +1246,8 @@
           }
         },
         "merchant-presets": {
-          "kind": "mount"
+          "kind": "mount",
+          "actor": "Compendium.dnd5e.actors24.Actor.mmPony0000000000"
         }
       },
       "_stats": {

--- a/scripts/merchant-presets.mjs
+++ b/scripts/merchant-presets.mjs
@@ -686,6 +686,107 @@ function registerMeals() {
   });
 }
 
+/* ------------------------------------------------------------------ animals */
+
+const ANIMAL_FOLDER = "Purchased Animals";
+
+/**
+ * Put a bought animal in the world.
+ *
+ * The SRD has no animal items: a riding horse is a stat block in
+ * dnd5e.actors24, the pack the shopkeepers are statted from. The goods the
+ * stables sell are therefore loot placeholders at the SRD price, each carrying
+ * an `actor` flag naming its stat block. When one is bought, the stat block is
+ * copied into the world — one actor per animal, in a "Purchased Animals"
+ * folder, owned by whoever owns the buying character — and the loot item
+ * becomes the bill of sale, linking to the creatures it stands for.
+ *
+ * Item Piles runs every trade through a GM, so one is always online; the
+ * active GM's client does the creating, which players are not allowed to.
+ * Nothing is placed on a scene: the GM drags the animal in from the sidebar.
+ * Selling the deed back is money only — the animal stays for the GM to deal
+ * with, since deleting actors unasked is not this module's business.
+ */
+async function deliverAnimals(sellerUuid, buyerUuid, itemPrices, userId) {
+  if (game.users.activeGM !== game.user) return;
+  if (!game.settings.get(MODULE, "animalsSpawn")) return;
+  const bought = (itemPrices?.buyerReceive ?? []).filter(e =>
+    e.quantity > 0 && e.item?.getFlag?.(MODULE, "actor"));
+  if (!bought.length) return;
+
+  const buyer = await fromUuid(buyerUuid);
+  const seller = await fromUuid(sellerUuid);
+  if (!buyer) return;
+
+  // Selling a deed to a merchant: the deed is the merchant's entry now.
+  if (game.itempiles?.API?.isItemPileMerchant?.(buyer)) {
+    const names = bought.map(e => e.item.name).join(", ");
+    await ChatMessage.create({
+      content: `<p><strong>${seller?.name ?? "Someone"}</strong> sold ${names} to ${buyer.name}. `
+        + `The animal is still in the <em>${ANIMAL_FOLDER}</em> folder for the GM to remove or keep.</p>`,
+      whisper: game.users.filter(u => u.isGM).map(u => u.id)
+    });
+    return;
+  }
+
+  const folder = await ensureFolder(ANIMAL_FOLDER, "Actor");
+  for (const entry of bought) {
+    try {
+      const uuids = await spawnAnimals(buyer, entry.item, entry.quantity, folder);
+      await recordDeed(buyer, entry.item, uuids);
+      const links = uuids.map(u => `@UUID[${u}]`).join(", ");
+      await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: buyer }),
+        content: `<p><strong>${buyer.name}</strong> bought ${entry.quantity > 1 ? `${entry.quantity} × ` : ""}`
+          + `${entry.item.name} from ${seller?.name ?? "a merchant"}: ${links}</p>`
+      });
+    } catch (err) {
+      console.error(`${MODULE} | could not deliver ${entry.item.name}`, err);
+    }
+  }
+}
+
+async function spawnAnimals(buyer, good, quantity, folder) {
+  const src = await fromUuid(good.getFlag(MODULE, "actor"));
+  if (!src) throw new Error(`stat block ${good.getFlag(MODULE, "actor")} not found — is the dnd5e system's SRD installed?`);
+  const data = game.actors.fromCompendium(src, { clearFolder: true, clearOwnership: true });
+  data.folder = folder.id;
+  data.ownership = { ...buyer.ownership };
+  if (good.img) {
+    data.img = good.img;
+    foundry.utils.setProperty(data, "prototypeToken.texture.src", good.img);
+  }
+  foundry.utils.setProperty(data, "prototypeToken.actorLink", true);
+  foundry.utils.setProperty(data, "prototypeToken.disposition", CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+  foundry.utils.setProperty(data, `flags.${MODULE}.boughtBy`, buyer.uuid);
+
+  const created = await Actor.implementation.createDocuments(
+    Array.from({ length: quantity }, () => foundry.utils.deepClone(data)));
+  return created.map(a => a.uuid);
+}
+
+/** Mark the buyer's copy of the good as the deed for these animals. */
+async function recordDeed(buyer, good, uuids) {
+  const source = good._stats?.compendiumSource ?? good.uuid;
+  const deed = buyer.items.find(i => i.name === good.name
+    && (i._stats?.compendiumSource === source || i.getFlag(MODULE, "actor") === good.getFlag(MODULE, "actor")));
+  if (!deed) return;
+  const all = [...(deed.getFlag(MODULE, "animals") ?? []), ...uuids];
+  const links = all.map(u => `@UUID[${u}]`).join(", ");
+  const desc = deed.system.description?.value ?? "";
+  const body = desc.replace(/<p class="mp-animals">.*?<\/p>/s, "");
+  await deed.update({
+    [`flags.${MODULE}.animals`]: all,
+    "system.description.value": `${body}<p class="mp-animals">Your ${all.length > 1 ? "animals" : "animal"}: ${links}</p>`
+  });
+}
+
+function registerAnimals() {
+  Hooks.on("item-piles-tradeItems", (...args) => {
+    deliverAnimals(...args).catch(err => console.error(`${MODULE} |`, err));
+  });
+}
+
 /* ----------------------------------------------------------------- settings */
 
 Hooks.once("init", () => {
@@ -792,6 +893,19 @@ Hooks.once("init", () => {
     type: Boolean,
     default: true
   });
+
+  game.settings.register(MODULE, "animalsSpawn", {
+    name: "Bought animals are added to the world",
+    hint: "The SRD has no animal items — a riding horse is a stat block — so the goods a stable "
+      + "sells are placeholders at the SRD price. With this on, buying one copies the SRD stat "
+      + "block into the world as an actor in a \"Purchased Animals\" folder, owned by whoever owns "
+      + "the buying character, and the item in their pack becomes the bill of sale linking to it. "
+      + "Nothing is placed on a scene; drag the animal in from the sidebar.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
+  });
 });
 
 Hooks.once("ready", () => {
@@ -818,6 +932,7 @@ Hooks.once("ready", () => {
 
   registerRestock();
   registerTradingHours();
+  registerAnimals();
   // Time moves while a world is closed, so put the shops on the right side of
   // their doors now rather than at the next tick of the clock.
   syncOpenStateAll().then(n => { if (n) log(`${n} shop(s) opened or closed for the hour`); });


### PR DESCRIPTION
The SRD has no animal **items** — a Riding Horse is a stat block in `dnd5e.actors24`, the same SRD pack the shopkeepers are statted from. Our eight animal goods were loot placeholders at the SRD price, so buying a horse gave the player a line in their pack and nothing else.

**What this does**
- Each animal good carries `flags.merchant-presets.actor = Compendium.dnd5e.actors24.Actor.<id>` and a *Stat block: @UUID* link in its description. Generator propagates it to the three Stables (stock and all other merchants byte-identical).
- On `item-piles-tradeItems`, the **active GM's client** (Item Piles runs every trade through a GM, and players can't create actors) copies the SRD actor into the world — one per animal bought — into a *Purchased Animals* folder, ownership copied from the buying character, linked token, friendly disposition, the good's icon as portrait/token (SRD animals ship `img: null`).
- The buyer's loot item becomes the deed: `flags.merchant-presets.animals = [uuids]` and a *Your animal: @UUID* line in its description. Chat card links the new actor(s).
- Selling a deed to a merchant: money only, plus a GM whisper that the animal is still in the folder. No automatic deletion.
- Setting *Bought animals are added to the world*, on by default. No module dependency beyond Item Piles.

README and CONTRIBUTING updated. Independent of #14 (meals) — both touch `tradeItems` but different sections; expect a trivial merge.

In-world smoke test (buy a horse at a Stable) still to do, together with the meals one. Not a release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)