### PR TITLE
Give the shopkeepers a neutral token disposition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ Thanks for your interest. Two halves to this repo, with different rules:
 and which settlement sizes carry them — and `tools/build_srd.py` turns that into
 `_source/merchants` and `_source/stock`.
 
+Shopkeeper tokens are neutral — a tradesperson is on nobody's side — unless the
+shop's recipe sets `disposition` (1 friendly, 0 neutral, -1 hostile, -2 secret).
+
 Regenerating is a separate, rarer step than packing, because it needs three of
 the dnd5e system's SRD compendiums unpacked to JSON — the equipment the shops
 sell, the actors the shopkeepers are statted from, and the monster features

--- a/_source/merchants/Adventurers_Store_City_bzURsHrQ4iwtPo4G.json
+++ b/_source/merchants/Adventurers_Store_City_bzURsHrQ4iwtPo4G.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/market-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Adventurers_Store_Town_WI49F1bXjoKrBaQg.json
+++ b/_source/merchants/Adventurers_Store_Town_WI49F1bXjoKrBaQg.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/market-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Adventurers_Store_Village_8ayCIZ7LmeYubyw4.json
+++ b/_source/merchants/Adventurers_Store_Village_8ayCIZ7LmeYubyw4.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/market-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
+++ b/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
@@ -551,7 +551,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/winemaker-still-vintner.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
+++ b/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/winemaker-still-vintner.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Alchemists_Apothecaries_Village_K4sX0S4KIIsXUeTZ.json
+++ b/_source/merchants/Alchemists_Apothecaries_Village_K4sX0S4KIIsXUeTZ.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/winemaker-still-vintner.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
+++ b/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
@@ -554,7 +554,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wizard-castle.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
+++ b/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wizard-castle.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Arcane_Store_Village_BhUHpOxQV6rSkfA4.json
+++ b/_source/merchants/Arcane_Store_Village_BhUHpOxQV6rSkfA4.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wizard-castle.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Armourer_Blacksmiths_City_PjzhoPPbwfYoLyho.json
+++ b/_source/merchants/Armourer_Blacksmiths_City_PjzhoPPbwfYoLyho.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/blacksmith.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Armourer_Blacksmiths_Town_vjHTqmO54VdBokKn.json
+++ b/_source/merchants/Armourer_Blacksmiths_Town_vjHTqmO54VdBokKn.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/blacksmith.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Armourer_Blacksmiths_Village_tr2tgfSP4zq5vXk8.json
+++ b/_source/merchants/Armourer_Blacksmiths_Village_tr2tgfSP4zq5vXk8.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/blacksmith.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Criminal_Illicit_Store_City_H5hL07qDuFQpaFT9.json
+++ b/_source/merchants/Criminal_Illicit_Store_City_H5hL07qDuFQpaFT9.json
@@ -547,7 +547,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/sewer-entrance.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Criminal_Illicit_Store_Town_Lur3FQEmjd5pcwPN.json
+++ b/_source/merchants/Criminal_Illicit_Store_Town_Lur3FQEmjd5pcwPN.json
@@ -550,7 +550,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/sewer-entrance.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Criminal_Illicit_Store_Village_mfHdaPywzU7n0bMd.json
+++ b/_source/merchants/Criminal_Illicit_Store_Village_mfHdaPywzU7n0bMd.json
@@ -547,7 +547,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/sewer-entrance.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Dock_City_AQvzAugD0mDLKKOn.json
+++ b/_source/merchants/Dock_City_AQvzAugD0mDLKKOn.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/abandoned-pier.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Dock_Town_6Ztn4A3Qmw7BqtaA.json
+++ b/_source/merchants/Dock_Town_6Ztn4A3Qmw7BqtaA.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/abandoned-pier.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Dock_Village_rZ8AENGyt2zmDGfd.json
+++ b/_source/merchants/Dock_Village_rZ8AENGyt2zmDGfd.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/abandoned-pier.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
+++ b/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
@@ -551,7 +551,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-woods.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
+++ b/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-woods.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Druidic_Store_Village_EN7eh38RFIQeOE1P.json
+++ b/_source/merchants/Druidic_Store_Village_EN7eh38RFIQeOE1P.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-woods.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Fletcher_Woodworker_City_zlyiXsGcSIYxDJfA.json
+++ b/_source/merchants/Fletcher_Woodworker_City_zlyiXsGcSIYxDJfA.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/lumbermill.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Fletcher_Woodworker_Town_4ehrvYemvvZQEVf1.json
+++ b/_source/merchants/Fletcher_Woodworker_Town_4ehrvYemvvZQEVf1.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/lumbermill.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Fletcher_Woodworker_Village_00tdck8znFTmgKym.json
+++ b/_source/merchants/Fletcher_Woodworker_Village_00tdck8znFTmgKym.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/lumbermill.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/General_Store_City_obRqh3VbEiefEINw.json
+++ b/_source/merchants/General_Store_City_obRqh3VbEiefEINw.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wood-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/General_Store_Town_57oHVmTqHdn2T8iW.json
+++ b/_source/merchants/General_Store_Town_57oHVmTqHdn2T8iW.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wood-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/General_Store_Village_L6zH6zpoDpLwHcwz.json
+++ b/_source/merchants/General_Store_Village_L6zH6zpoDpLwHcwz.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/wood-stall.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
+++ b/_source/merchants/Inn_Tavern_City_Ei1x8J4RXvsHELuA.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/tavern.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
+++ b/_source/merchants/Inn_Tavern_Town_sOFPI6SlXbpGLE78.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/tavern.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
+++ b/_source/merchants/Inn_Tavern_Village_q3fWf3cBWITAW2hl.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/tavern.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Jeweler_City_e4aPnMG6goFT0zMy.json
+++ b/_source/merchants/Jeweler_City_e4aPnMG6goFT0zMy.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-city.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Jeweler_Town_jwnx9SR2cla6JDNr.json
+++ b/_source/merchants/Jeweler_Town_jwnx9SR2cla6JDNr.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-city.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Jeweler_Village_qvDF1F8ozMgRrsxU.json
+++ b/_source/merchants/Jeweler_Village_qvDF1F8ozMgRrsxU.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-city.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Leatherworker_City_ynVWaEF6RzWJdx78.json
+++ b/_source/merchants/Leatherworker_City_ynVWaEF6RzWJdx78.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories-small.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Leatherworker_Town_rrXsKno8WincEfQz.json
+++ b/_source/merchants/Leatherworker_Town_rrXsKno8WincEfQz.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories-small.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Leatherworker_Village_pptkk5NYSf6vOZg0.json
+++ b/_source/merchants/Leatherworker_Village_pptkk5NYSf6vOZg0.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories-small.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Musical_Store_City_DcfxAJhKMhypgiIL.json
+++ b/_source/merchants/Musical_Store_City_DcfxAJhKMhypgiIL.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/gazebo.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Musical_Store_Town_y10ZroQxND6Eq6LS.json
+++ b/_source/merchants/Musical_Store_Town_y10ZroQxND6Eq6LS.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/gazebo.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Musical_Store_Village_0oaW05C0ZXUwucp5.json
+++ b/_source/merchants/Musical_Store_Village_0oaW05C0ZXUwucp5.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/gazebo.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
+++ b/_source/merchants/Stable_City_4DQbiFzQ4plCkZBb.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/stables-horses.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
+++ b/_source/merchants/Stable_Town_TiaBEntO182vijRR.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/stables-horses.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
+++ b/_source/merchants/Stable_Village_g0ikO5OJ7DMCvp3I.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/stables-horses.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tailor_Textile_Store_City_fWpfjHUwCxMUHWhm.json
+++ b/_source/merchants/Tailor_Textile_Store_City_fWpfjHUwCxMUHWhm.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tailor_Textile_Store_Town_QD6M8RWl2t1vY5bR.json
+++ b/_source/merchants/Tailor_Textile_Store_Town_QD6M8RWl2t1vY5bR.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tailor_Textile_Store_Village_mAoxOdpA6pn04CGc.json
+++ b/_source/merchants/Tailor_Textile_Store_Village_mAoxOdpA6pn04CGc.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/house-two-stories.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
+++ b/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
@@ -552,7 +552,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/church.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
+++ b/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/church.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
+++ b/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/church.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
+++ b/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
@@ -554,7 +554,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/pottery-shop-shed-red.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tinkering_Store_Town_IZ2qsuJc4ynG0OMI.json
+++ b/_source/merchants/Tinkering_Store_Town_IZ2qsuJc4ynG0OMI.json
@@ -549,7 +549,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/pottery-shop-shed-red.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/_source/merchants/Tinkering_Store_Village_mdqxFzOKITaPFR3Q.json
+++ b/_source/merchants/Tinkering_Store_Village_mdqxFzOKITaPFR3Q.json
@@ -546,7 +546,8 @@
     "actorLink": true,
     "texture": {
       "src": "icons/environment/settlement/pottery-shop-shed-red.webp"
-    }
+    },
+    "disposition": 0
   },
   "items": [
     {

--- a/tools/build_srd.py
+++ b/tools/build_srd.py
@@ -461,7 +461,13 @@ def main():
                 "_id": aid, "_key": f"!actors!{aid}", "name": name, "type": "npc",
                 "img": shop["img"], "folder": fold_a[key], "sort": 0,
                 "system": sysd,
-                "prototypeToken": {"name": name, "actorLink": True, "texture": {"src": shop["img"]}},
+                "prototypeToken": {"name": name, "actorLink": True, "texture": {"src": shop["img"]},
+                                   # Unset, Foundry defaults a token to HOSTILE: a shopkeeper
+                                   # with a red border, listed as an enemy in the tracker.
+                                   # Neutral is what a tradesperson is — not on the party's
+                                   # side, not against it. A recipe may override per shop
+                                   # (1 friendly, 0 neutral, -1 hostile, -2 secret).
+                                   "disposition": shop.get("disposition", 0)},
                 "items": items + gear, "effects": [], "ownership": {"default": 0},
                 "flags": {
                     # The shop's own record of itself: what its purse should be


### PR DESCRIPTION
The generator never set `prototypeToken.disposition`, and Foundry defaults an unset token to **HOSTILE** — so all 51 shopkeepers got a red border and showed as enemies in the combat tracker. Since 1.0.0.

They are now **neutral** (a tradesperson is on nobody's side; the green friendly border means an ally). A shop recipe may set `disposition` to override per shop — none does. Regenerated: one line per merchant, stock tables untouched. Merchants already in a world keep their existing token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)