### PR TITLE
Track work in issues and milestones, and release from a changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 # What does this PR change?
 
+Closes #
 
 
 ## Checklist
@@ -10,4 +11,5 @@
       and the world was closed while building
 - [ ] Nothing references the paid Player's Handbook or Dungeon Master's Guide
       modules — everything resolves against SRD 5.2
-- [ ] No version bump in `module.json` (releases are cut by the maintainer)
+- [ ] A line under `[Unreleased]` in `CHANGELOG.md`, written for GMs
+- [ ] No version bump in `module.json` (that happens in the release PR)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,16 @@ jobs:
 
           echo "module.json OK (id=$id version=$version)"
 
+      - name: CHANGELOG keeps an Unreleased section
+        run: |
+          set -euo pipefail
+          grep -q '^## \[Unreleased\]' CHANGELOG.md || { echo "CHANGELOG.md lost its [Unreleased] section" >&2; exit 1; }
+          # The last release must be documented: the tag workflow refuses to
+          # publish without its section, so catch a missing one here first.
+          version="$(jq -r .version module.json)"
+          grep -q "^## \[$version\]" CHANGELOG.md || { echo "CHANGELOG.md has no [$version] section for module.json's version" >&2; exit 1; }
+          echo "CHANGELOG OK"
+
       - name: Compendium sources are valid JSON
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: write
+  # To close the release's milestone once it ships.
+  issues: write
 
 jobs:
   validate:
@@ -65,24 +67,30 @@ jobs:
             -x "*.git*" -x ".github/*" -x "_source/*" -x "tools/*" \
             -x "node_modules/*" -x "package*.json"
 
+      - name: Require a CHANGELOG section for this version
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no [$VERSION] section — run 'npm run release:prepare -- $VERSION' and release via a PR" >&2
+            exit 1
+          fi
+
       - name: Build release notes
         run: |
           set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
           PREV="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
           {
-            echo "## What's changed"
-            echo ""
-            # Commit subjects since the previous tag, skipping merge commits
-            # and commits that only touch CI/workflow files — players care
-            # about neither. Without --no-merges a release batching several
-            # pull requests lists some of them twice: once as the change and
-            # once as "Merge pull request #N from ...".
-            if [ -n "$PREV" ]; then
-              RANGE="$PREV..${GITHUB_REF_NAME}"
-            else
-              RANGE="${GITHUB_REF_NAME}"
-            fi
-            git log --no-merges --pretty='- %s' "$RANGE" -- . ':!.github'
+            # The body is the CHANGELOG section written alongside the changes,
+            # not a git log: commit subjects are for developers, release notes
+            # are for the GMs installing the module.
+            node -e '
+              import("./tools/changelog.mjs").then(({ changelogSection }) => {
+                const text = require("fs").readFileSync("CHANGELOG.md", "utf8");
+                process.stdout.write(changelogSection(text, process.argv[1]) + "\n");
+              });
+            ' "$VERSION"
             echo ""
             if [ -n "$PREV" ]; then
               echo "**Full changelog:** [\`$PREV...${GITHUB_REF_NAME}\`](https://github.com/${GITHUB_REPOSITORY}/compare/$PREV...${GITHUB_REF_NAME})"
@@ -97,7 +105,7 @@ jobs:
               echo "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/module.json"
               echo '```'
             else
-              echo "Paste this manifest URL into Foundry's **Install Module** dialog:"
+              echo "Paste this manifest URL into Foundry's **Install Module** dialog, or update from the Add-on Modules tab:"
               echo ""
               echo '```'
               echo "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/module.json"
@@ -136,3 +144,24 @@ jobs:
             echo "Foundry registry publish failed with HTTP $STATUS" >&2
             exit 1
           fi
+
+      - name: Close the release milestone
+        if: ${{ steps.prerelease.outputs.is_prerelease != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Milestones are named after the tag (v1.2.0). Shipping closes it;
+          # anything still open inside it is reported, not silently carried.
+          NUMBER="$(gh api "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+            --jq ".[] | select(.title == \"${GITHUB_REF_NAME}\") | .number")"
+          if [ -z "$NUMBER" ]; then
+            echo "no open milestone named ${GITHUB_REF_NAME} — nothing to close"
+            exit 0
+          fi
+          OPEN="$(gh api "repos/${GITHUB_REPOSITORY}/milestones/$NUMBER" --jq .open_issues)"
+          if [ "$OPEN" != "0" ]; then
+            echo "::warning::milestone ${GITHUB_REF_NAME} still has $OPEN open issue(s); move them to the next milestone"
+          fi
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/milestones/$NUMBER" -f state=closed > /dev/null
+          echo "closed milestone ${GITHUB_REF_NAME} (#$NUMBER)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to Merchant Presets are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and versions follow
+[Semantic Versioning](https://semver.org/). Each release's section is also the
+body of its GitHub release.
+
+Add an entry under **Unreleased** in the same pull request as the change, under
+_Added_, _Changed_, _Fixed_ or _Removed_, written for players and GMs rather
+than for the code. Reference the issue or PR it closes.
+
+## [Unreleased]
+
+### Added
+
+- Buying an animal puts a copy of its SRD stat block in the world, ready to
+  drop on a scene (#15)
+- Buying a meal offers to eat it on the spot (#14)
+
+### Changed
+
+- Shopkeeper tokens are neutral rather than friendly; a shop recipe can set
+  `disposition` to override (#16)
+
+### Fixed
+
+- Broken icons on the spell-component gems (#13)
+
+## [1.1.0] - 2026-08-22
+
+### Added
+
+- Shops open and close on the world clock, driving Item Piles' own open/closed
+  status from Foundry's world time. On by default; the setting hands every shop
+  back to always-open (#5)
+- Every shopkeeper carries an SRD 5.2 stat block that escalates with the
+  settlement size. Gear is tagged so it never reaches the shelf and restocking
+  never treats it as merchandise (#9)
+- _Shop stock is not carried_ — an opt-in setting that cancels the weight of
+  the stock so the Encumbrance variant rule only counts the shopkeeper's own
+  kit (#8)
+
+### Changed
+
+- The `drink` goods kind is renamed `food-drink` (#6)
+- The generator no longer indexes the SRD equipment pack's folders, so a stock
+  line named "Potions" cannot resolve to a folder (#4)
+- README: accurate Merchant Goods counts, status badges; build instructions
+  moved to CONTRIBUTING (#3)
+- Releases are gated on the CI validation (#10)
+
+## [1.0.0] - 2026-08-20
+
+### Added
+
+- Fifty-one SRD 5.2 shops as Item Piles merchants — seventeen stores in
+  Village, Town and City sizes, each pre-stocked and priced
+- Opt-in restocking that preserves flags and refills the till
+- Containers stocked as separate items, one each
+- Original item descriptions and SRD prices throughout
+
+[Unreleased]: https://github.com/mikiross87/merchant-presets/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/mikiross87/merchant-presets/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/mikiross87/merchant-presets/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,14 @@ Four constraints worth knowing before changing the generator:
   paid-content check.
 - One logical change per PR, with a subject line that would read well in release
   notes — commit subjects become release-note bullets.
-- Don't bump `version` in `module.json`. Between releases it carries the *next*
-  version with a `-dev` suffix (e.g. `1.1.0-dev`); the maintainer sets the real
-  version when tagging.
+- Open an issue first for anything beyond a typo, and put `Closes #N` in the PR
+  body so merging closes it. Issues go through the forms; there are no blank
+  issues.
+- Add a line under `[Unreleased]` in `CHANGELOG.md` — _Added_, _Changed_,
+  _Fixed_ or _Removed_ — written for the GM reading the release page. That
+  section becomes the release notes verbatim.
+- Don't bump `version` in `module.json`. `main` carries the version of the last
+  release; the bump happens in a release PR (see [RELEASING.md](RELEASING.md)).
 
 ## Releases (maintainer)
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Every price, weight and description is the SRD's, with no exceptions.
 
 ## Contributing
 
-Building the packs, changing what the shops stock, and cutting releases are all
-covered in [CONTRIBUTING.md](CONTRIBUTING.md).
+Found a problem or want a shop that isn't here? [Open an issue](https://github.com/mikiross87/merchant-presets/issues/new/choose).
+Building the packs and changing what the shops stock are covered in
+[CONTRIBUTING.md](CONTRIBUTING.md); what changed in each version is in
+[CHANGELOG.md](CHANGELOG.md), and the release process in [RELEASING.md](RELEASING.md).
 
 ## Legal
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,85 @@
+# Maintenance and releases
+
+How work gets from "something is wrong" to a version GMs can install. The
+contributor-facing half is in [CONTRIBUTING.md](CONTRIBUTING.md); this is the
+maintainer's loop.
+
+## The loop
+
+```
+issue ──► milestone ──► branch + PR (Closes #N) ──► main ──► release PR ──► tag ──► CI publishes
+```
+
+1. **Every problem or improvement is an issue** — even ones you fix yourself
+   five minutes later. Issues are the record; commits are the implementation.
+   Issues arrive through the forms, which label them `bug` or `enhancement`.
+   Add one of the work-type labels when triaging:
+
+   | label         | means                                                     |
+   | ------------- | --------------------------------------------------------- |
+   | `content`     | shops, stock, goods, prices — `data/` and `_source/`      |
+   | `maintenance` | CI, tooling, docs, dependencies; nothing a GM would notice |
+   | `regression`  | worked in a previous release; prioritise it               |
+
+2. **A milestone is a planned release**, named after its tag: `v1.2.0`. Assign
+   an issue to a milestone when you intend to ship it there; leave it
+   unassigned while it is only a wish. The milestone's progress bar is the
+   release plan, and a bug found after a release goes into the next patch
+   milestone (`v1.2.1`) rather than back into the shipped one.
+
+3. **One branch and PR per issue**, with `Closes #N` in the PR body so merging
+   closes the issue and GitHub links the two. Add a line under `[Unreleased]`
+   in `CHANGELOG.md` in the same PR — written for the GM reading the release
+   page, not the developer reading `git log`.
+
+4. **`main` is always last release + merged work.** `module.json` carries the
+   version of the last release until the release PR bumps it; the unreleased
+   work is visible in `CHANGELOG.md` and the open milestone, not in a
+   pre-release version string that Foundry would show to players.
+
+## Cutting a release
+
+When the milestone is done (or you decide to ship what's there and move the
+rest):
+
+```sh
+git checkout main && git pull
+npm run release:prepare -- 1.2.0      # bumps module.json, rolls the changelog, commits on release/v1.2.0
+git push -u origin release/v1.2.0
+gh pr create --fill --milestone v1.2.0
+```
+
+Review the `[1.2.0]` section — it becomes the release body — and merge once
+CI is green. Then tag **main's post-merge HEAD**, not the release branch:
+
+```sh
+git checkout main && git pull
+git tag -a v1.2.0 -m "v1.2.0"
+git push origin v1.2.0
+```
+
+The tag triggers `release.yml`, which re-runs CI on the tagged tree, checks the
+tag matches `module.json`, refuses to run without a `[1.2.0]` changelog
+section, builds the packs and `module.zip`, creates the GitHub release with the
+changelog section as its body, publishes to the Foundry package registry, and
+closes the `v1.2.0` milestone (warning if issues are still open in it).
+
+Never `gh release create` by hand: it makes a lightweight tag, skips CI, and
+since GitHub made releases immutable the tag name can never be reused if it
+goes wrong. `gh release edit --notes` is fine for polishing the body afterwards.
+
+## Versioning
+
+- **patch** (`1.2.1`) — fixes only; no new shops, settings or behaviour
+- **minor** (`1.3.0`) — new shops, goods, settings, or behaviour that is
+  backwards compatible with existing worlds
+- **major** (`2.0.0`) — existing merchants in a world need migrating, or the
+  minimum Foundry / dnd5e / Item Piles version rises
+
+Prereleases (`1.3.0-beta.1`) go through the same flow; CI marks them as
+GitHub prereleases, skips the Foundry registry, and leaves the milestone open.
+
+## Hotfixes
+
+Branch from `main`, fix, PR, then release as a patch. There are no long-lived
+release branches to backport to: a hotfix is just a small release.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.2.0-dev",
+  "version": "1.1.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "pack": "npm run pack:merchants && npm run pack:stock && npm run pack:goods",
     "pack:merchants": "fvtt package pack -n merchants --id merchant-presets --type Module --in _source/merchants --out packs",
     "pack:stock": "fvtt package pack -n stock --id merchant-presets --type Module --in _source/stock --out packs",
-    "pack:goods": "fvtt package pack -n goods --id merchant-presets --type Module --in _source/goods --out packs"
+    "pack:goods": "fvtt package pack -n goods --id merchant-presets --type Module --in _source/goods --out packs",
+    "release:prepare": "node tools/prepare-release.mjs"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^3.0.3"

--- a/tools/changelog.mjs
+++ b/tools/changelog.mjs
@@ -1,0 +1,50 @@
+// Keep a Changelog helpers shared by tools/prepare-release.mjs and its tests.
+// Pure string transforms, so they can be unit-tested without git or a repo.
+
+const UNRELEASED = "## [Unreleased]";
+
+/** Text of the `## [version]` section, without its heading, or null. */
+export function changelogSection(text, version) {
+  const lines = text.split("\n");
+  const heading = `## [${version}]`;
+  const start = lines.findIndex((l) => l.startsWith(heading));
+  if (start === -1) return null;
+  let end = lines.findIndex((l, i) => i > start && l.startsWith("## "));
+  if (end === -1) end = lines.findIndex((l, i) => i > start && /^\[[^\]]+\]: /.test(l));
+  if (end === -1) end = lines.length;
+  return lines.slice(start + 1, end).join("\n").trim();
+}
+
+/**
+ * Move everything under [Unreleased] into a new `## [version] - date`
+ * section and repoint the footer compare links. Throws if there is nothing
+ * to release or the version already has a section.
+ */
+export function rollChangelog(text, version, date, repo) {
+  if (changelogSection(text, version) !== null) {
+    throw new Error(`CHANGELOG.md already has a [${version}] section`);
+  }
+  const body = changelogSection(text, "Unreleased");
+  if (body === null) throw new Error("CHANGELOG.md has no [Unreleased] section");
+  if (body === "") throw new Error("[Unreleased] is empty — nothing to release");
+
+  const previous = text.match(/^## \[(\d+\.\d+\.\d+[^\]]*)\]/m)?.[1] ?? null;
+
+  let out = text.replace(
+    `${UNRELEASED}\n\n${body}`,
+    `${UNRELEASED}\n\n## [${version}] - ${date}\n\n${body}`,
+  );
+
+  const base = `https://github.com/${repo}`;
+  const unreleasedLink = `[Unreleased]: ${base}/compare/v${version}...HEAD`;
+  const versionLink = previous
+    ? `[${version}]: ${base}/compare/v${previous}...v${version}`
+    : `[${version}]: ${base}/releases/tag/v${version}`;
+
+  if (/^\[Unreleased\]: /m.test(out)) {
+    out = out.replace(/^\[Unreleased\]: .*$/m, `${unreleasedLink}\n${versionLink}`);
+  } else {
+    out = `${out.trimEnd()}\n\n${unreleasedLink}\n${versionLink}\n`;
+  }
+  return out;
+}

--- a/tools/changelog.test.mjs
+++ b/tools/changelog.test.mjs
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { changelogSection, rollChangelog } from "./changelog.mjs";
+
+const repo = "mikiross87/merchant-presets";
+const sample = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Something new (#20)
+
+## [1.1.0] - 2026-08-22
+
+### Added
+
+- Shops open and close
+
+[Unreleased]: https://github.com/${repo}/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/${repo}/compare/v1.0.0...v1.1.0
+`;
+
+test("extracts a section body without its heading", () => {
+  assert.equal(changelogSection(sample, "1.1.0"), "### Added\n\n- Shops open and close");
+  assert.equal(changelogSection(sample, "Unreleased"), "### Added\n\n- Something new (#20)");
+  assert.equal(changelogSection(sample, "9.9.9"), null);
+});
+
+test("rolls Unreleased into a dated section and repoints the footer links", () => {
+  const out = rollChangelog(sample, "1.2.0", "2026-08-23", repo);
+  assert.match(out, /^## \[Unreleased\]\n\n## \[1\.2\.0\] - 2026-08-23\n\n### Added\n\n- Something new \(#20\)\n\n## \[1\.1\.0\]/m);
+  assert.equal(changelogSection(out, "Unreleased"), "");
+  assert.match(out, new RegExp(`^\\[Unreleased\\]: https://github.com/${repo}/compare/v1\\.2\\.0\\.\\.\\.HEAD$`, "m"));
+  assert.match(out, new RegExp(`^\\[1\\.2\\.0\\]: https://github.com/${repo}/compare/v1\\.1\\.0\\.\\.\\.v1\\.2\\.0$`, "m"));
+  assert.match(out, /^\[1\.1\.0\]: /m);
+});
+
+test("refuses an empty Unreleased section", () => {
+  const empty = sample.replace("### Added\n\n- Something new (#20)\n\n", "");
+  assert.throws(() => rollChangelog(empty, "1.2.0", "2026-08-23", repo), /nothing to release/);
+});
+
+test("refuses to release a version that already has a section", () => {
+  assert.throws(() => rollChangelog(sample, "1.1.0", "2026-08-23", repo), /already has/);
+});
+
+test("first release links to the tag when there is no previous version", () => {
+  const first = `# Changelog\n\n## [Unreleased]\n\n- Initial\n`;
+  const out = rollChangelog(first, "1.0.0", "2026-08-20", repo);
+  assert.match(out, new RegExp(`^\\[1\\.0\\.0\\]: https://github.com/${repo}/releases/tag/v1\\.0\\.0$`, "m"));
+});

--- a/tools/prepare-release.mjs
+++ b/tools/prepare-release.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Stage a release: bump module.json, roll CHANGELOG.md's [Unreleased] into a
+// dated section, and commit on a release/vX.Y.Z branch ready for a PR.
+//
+//   npm run release:prepare -- 1.2.0
+//
+// Tagging is a separate, deliberate step after the PR merges — see RELEASING.md.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { rollChangelog } from "./changelog.mjs";
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error("usage: npm run release:prepare -- X.Y.Z[-prerelease]");
+  process.exit(2);
+}
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+
+if (git("status", "--porcelain") !== "") {
+  console.error("working tree is not clean — commit or stash first");
+  process.exit(1);
+}
+const branch = git("rev-parse", "--abbrev-ref", "HEAD");
+if (branch !== "main") {
+  console.error(`run this from main (currently on ${branch})`);
+  process.exit(1);
+}
+git("fetch", "origin", "main");
+if (git("rev-parse", "HEAD") !== git("rev-parse", "origin/main")) {
+  console.error("local main is not at origin/main — pull first");
+  process.exit(1);
+}
+if (git("tag", "-l", `v${version}`) !== "") {
+  console.error(`tag v${version} already exists`);
+  process.exit(1);
+}
+
+const module_ = JSON.parse(readFileSync("module.json", "utf8"));
+const repo = new URL(module_.url).pathname.slice(1);
+const date = new Date().toISOString().slice(0, 10);
+
+const changelog = rollChangelog(readFileSync("CHANGELOG.md", "utf8"), version, date, repo);
+
+// Rewrite only the version field so the rest of module.json keeps its formatting.
+const manifest = readFileSync("module.json", "utf8");
+const bumped = manifest.replace(/("version":\s*")[^"]+(")/, `$1${version}$2`);
+if (bumped === manifest) {
+  console.error("could not find the version field in module.json");
+  process.exit(1);
+}
+
+const release = `release/v${version}`;
+if (git("branch", "--list", release) !== "") {
+  console.error(`branch ${release} already exists — delete it or pick another version`);
+  process.exit(1);
+}
+git("checkout", "-b", release);
+writeFileSync("CHANGELOG.md", changelog);
+writeFileSync("module.json", bumped);
+git("add", "CHANGELOG.md", "module.json");
+git("commit", "-m", `chore(release): v${version}`);
+
+console.log(`
+Staged v${version} on ${release} (${module_.version} -> ${version}).
+
+Review the [${version}] section of CHANGELOG.md, then:
+
+  git push -u origin ${release}
+  gh pr create --fill --milestone v${version}
+
+After the PR merges, tag main (never the release branch) — see RELEASING.md:
+
+  git checkout main && git pull
+  git tag -a v${version} -m "v${version}" && git push origin v${version}
+`);


### PR DESCRIPTION
# What does this PR change?

Sets up the maintenance loop: issue → milestone → PR (`Closes #N`) → release PR → tag → CI.

- **`CHANGELOG.md`** (Keep a Changelog), back-filled for 1.0.0 and 1.1.0, with the four merged-since-1.1.0 changes under `[Unreleased]`. Its section becomes the GitHub release body instead of a `git log` dump.
- **No more `-dev` bump after each tag.** `module.json` on `main` is the last released version (reset to `1.1.0`); the next version lives in the milestone and `[Unreleased]`. `npm run release:prepare -- X.Y.Z` stages the one release commit on `release/vX.Y.Z` (guards: clean tree, on `main` at `origin/main`, tag/branch not taken, non-empty `[Unreleased]`).
- **`release.yml`** refuses a tag without a matching changelog section, uses the section as the notes, and closes the `vX.Y.Z` milestone (warns if issues are still open in it).
- **`ci.yml`** checks `[Unreleased]` exists and the current version is documented.
- **`RELEASING.md`** documents the loop, versioning rules and hotfixes; CONTRIBUTING, the PR template and README point at it.
- Labels `content`, `maintenance`, `regression` and milestone `v1.2.0` created on the repo.

## Checklist

- [x] `npm test` passes (11 tests, 5 new for the changelog roll)
- [x] `release:prepare` dry-run in a scratch clone produced the expected commit
- [x] No paid-content references
- [x] Changelog entry — this PR is maintenance; `[Unreleased]` lists the player-visible changes since 1.1.0
- [x] No version bump beyond resetting `1.2.0-dev` → `1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss1qtMk17VZzzTo6DLjqJ2