### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ than for the code. Reference the issue or PR it closes.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-23
+
 ### Added
 
 - Buying an animal puts a copy of its SRD stat block in the world, ready to
@@ -59,6 +61,7 @@ than for the code. Reference the issue or PR it closes.
 - Containers stocked as separate items, one each
 - Original item descriptions and SRD prices throughout
 
-[Unreleased]: https://github.com/mikiross87/merchant-presets/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/mikiross87/merchant-presets/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/mikiross87/merchant-presets/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mikiross87/merchant-presets/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mikiross87/merchant-presets/releases/tag/v1.0.0

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "compatibility": {
     "minimum": "14",
     "verified": "14"


### PR DESCRIPTION
# What does this PR change?

Release v1.2.0: bumps `module.json` to 1.2.0 and rolls `[Unreleased]` into the `[1.2.0]` changelog section (#13–#16, milestone v1.2.0). After merge, `main` gets tagged `v1.2.0`.

## Checklist

- [x] Changelog section reviewed — it becomes the release body
- [x] Version bump is the release PR's job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss1qtMk17VZzzTo6DLjqJ2