### PR TITLE
Count goods eaten through their Consume activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ than for the code. Reference the issue or PR it closes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Using the Consume activity on ale, wine, bread or cheese from the character
+  sheet now counts towards Simple Nutrition 5e, the same as consuming it through
+  Simple Nutrition's own dialog. New world setting *Eating from the sheet
+  counts*, on by default (#19)
+
 ## [1.2.0] - 2026-08-23
 
 ### Added

--- a/scripts/merchant-presets.mjs
+++ b/scripts/merchant-presets.mjs
@@ -18,7 +18,7 @@
  *    settlement size, so two copies of the same shop differ.
  */
 
-import { applyMeal } from "./nutrition.mjs";
+import { applyMeal, nutritionOfItem, usageConsumes } from "./nutrition.mjs";
 
 const MODULE = "merchant-presets";
 const STOCK_PREFIX = `Compendium.${MODULE}.stock.RollTable.`;
@@ -686,6 +686,67 @@ function registerMeals() {
   });
 }
 
+/* ------------------------------------------------------- eating by activity */
+
+/**
+ * Count a good eaten or drunk through its own Consume activity.
+ *
+ * Simple Nutrition 5e only records nutrition from its own dialog; it watches
+ * no item-use hook, so using the activity on a bottle of wine from the sheet
+ * empties the bottle and feeds nobody (#19). This listens to
+ * `dnd5e.postUseActivity`, which fires only on the using client — the one
+ * that owns the character — and records what Simple Nutrition would have for
+ * the same item, by its own rules. Scoped to this module's goods: every other
+ * item is Simple Nutrition's business (Kapuzenjoe/simple-nutrition-5e#4).
+ *
+ * dnd5e has already consumed the use and reduced the quantity by the time
+ * this fires; a use with consumption unticked is not a meal.
+ */
+async function countActivityMeal(activity, usageConfig) {
+  const item = activity?.item;
+  const actor = item?.actor;
+  if (!actor || actor.type !== "character") return;
+  if (!item.getFlag(MODULE, "kind")) return;                // our goods only
+  if (!game.modules.get(NUTRITION_MODULE)?.active) return;
+  if (!game.settings.get(MODULE, "activityFeeds")) return;
+  if (!usageConsumes(usageConfig)) return;
+
+  const base = `modules/${NUTRITION_MODULE}/scripts`;
+  const [cfg, sn] = await Promise.all([
+    import(foundry.utils.getRoute(`${base}/config.mjs`)),
+    import(foundry.utils.getRoute(`${base}/nutrition/actor.mjs`))
+  ]);
+  const nutrition = nutritionOfItem({
+    type: item.type,
+    consumableType: item.system.type?.value,
+    identifier: item.system.identifier,
+    weightLb: game.dnd5e.utils.convertWeight(item.system.weight?.value ?? 0, item.system.weight?.units ?? "lb", "lb")
+  }, cfg.WATER_IDENTIFIERS, cfg.WATER_ITEM_AMOUNT);
+  if (!nutrition) return;
+
+  const needs = sn.getNutritionNeeds(actor);
+  const has = {
+    malnourished: actor.hasConditionEffect(cfg.CONDITION_EFFECT_MALNOURISHED),
+    dehydrated: actor.hasConditionEffect(cfg.CONDITION_EFFECT_DEHYDRATED)
+  };
+  const result = applyMeal(sn.getNutritionState(actor), needs, nutrition, 1, has);
+  await sn.setNutritionState(actor, result.state);
+  if (result.clearMalnutrition) await actor.toggleStatusEffect(cfg.CONDITION_MALNUTRITION, { active: false });
+  if (result.clearDehydration) await actor.toggleStatusEffect(cfg.CONDITION_DEHYDRATION, { active: false });
+
+  const what = nutrition.water
+    ? `Drink ${sn.formatNutritionAmount("water", nutrition.water)}`
+    : `Food ${sn.formatNutritionAmount("food", nutrition.food)}`;
+  ui.notifications.info(`${actor.name}: ${item.name} — ${what}`);
+  log(`${actor.name} consumed ${item.name} by activity: food ${result.state.food}, water ${result.state.water}`);
+}
+
+function registerActivityMeals() {
+  Hooks.on("dnd5e.postUseActivity", (activity, usageConfig) => {
+    countActivityMeal(activity, usageConfig).catch(err => console.error(`${MODULE} |`, err));
+  });
+}
+
 /* ------------------------------------------------------------------ animals */
 
 const ANIMAL_FOLDER = "Purchased Animals";
@@ -894,6 +955,17 @@ Hooks.once("init", () => {
     default: true
   });
 
+  game.settings.register(MODULE, "activityFeeds", {
+    name: "Eating from the sheet counts",
+    hint: "With Simple Nutrition 5e installed, using the Consume activity on ale, wine, bread or cheese "
+      + "from a character sheet records the food or water, as if it had been consumed through Simple "
+      + "Nutrition's own dialog. Off: only that dialog counts.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
+  });
+
   game.settings.register(MODULE, "animalsSpawn", {
     name: "Bought animals are added to the world",
     hint: "The SRD has no animal items — a riding horse is a stat block — so the goods a stable "
@@ -918,6 +990,7 @@ Hooks.once("ready", () => {
   registerDrinks();
   // The buyer's own client answers the meal prompt, so this is for players too.
   registerMeals();
+  registerActivityMeals();
 
   if (!game.user.isGM) return;
   if (!game.modules.get("item-piles")?.active) {

--- a/scripts/nutrition.mjs
+++ b/scripts/nutrition.mjs
@@ -34,3 +34,45 @@ export function applyMeal(state, needs, nutrition, quantity, has) {
     clearDehydration
   };
 }
+
+/**
+ * What one unit of an item is worth when eaten or drunk, by Simple Nutrition's
+ * own rules (scripts/nutrition/hooks.mjs, getFoodCandidates/getWaterCandidates):
+ * only consumables; a registered water identifier is a pint of water and never
+ * food; any other consumable of type "food" is food by its weight in pounds.
+ * Loose "water-pint" only counts inside a waterskin, which needs the live
+ * document to judge, so it is left to Simple Nutrition's own dialog.
+ *
+ * @param {object} item  { type, consumableType, identifier, weightLb }
+ * @param {Set<string>} waterIdentifiers  Simple Nutrition's WATER_IDENTIFIERS.
+ * @param {number} waterAmount  Simple Nutrition's WATER_ITEM_AMOUNT (gallons).
+ * @returns {{ food: number, water: number } | null}  null when it is not nutrition.
+ */
+export function nutritionOfItem(item, waterIdentifiers, waterAmount) {
+  if (item.type !== "consumable") return null;
+  if (waterIdentifiers.has(item.identifier)) {
+    if (item.identifier === "water-pint") return null;
+    return { food: 0, water: waterAmount };
+  }
+  if (item.consumableType !== "food") return null;
+  if (item.identifier === "waterskin") return null;
+  if (!(item.weightLb > 0)) return null;
+  return { food: item.weightLb, water: 0 };
+}
+
+/**
+ * Did an activity use actually consume its item? dnd5e lets the user untick
+ * consumption in the usage dialog, which lands in usageConfig.consume as
+ * false, { resources: false } or an empty resources list.
+ *
+ * @param {object} usageConfig  dnd5e's ActivityUseConfiguration.
+ * @returns {boolean}
+ */
+export function usageConsumes(usageConfig) {
+  const consume = usageConfig?.consume;
+  if (consume === false) return false;
+  const resources = consume?.resources;
+  if (resources === false) return false;
+  if (Array.isArray(resources) && resources.length === 0) return false;
+  return true;
+}

--- a/tools/nutrition.test.mjs
+++ b/tools/nutrition.test.mjs
@@ -43,3 +43,36 @@ test("untouched state fields survive", () => {
   const r = applyMeal({ food: 0, water: 0, starvation: 3 }, needs, modest, 1, {});
   assert.equal(r.state.starvation, 3);
 });
+
+import { nutritionOfItem, usageConsumes } from "../scripts/nutrition.mjs";
+
+const water = new Set(["water-pint", "ale", "wine-common"]);
+const ale = { type: "consumable", consumableType: "food", identifier: "ale", weightLb: 0.5 };
+const bread = { type: "consumable", consumableType: "food", identifier: "bread", weightLb: 1 };
+
+test("a registered drink is water, worth one pint, never food", () => {
+  assert.deepEqual(nutritionOfItem(ale, water, 0.125), { food: 0, water: 0.125 });
+});
+
+test("other food consumables are food by weight", () => {
+  assert.deepEqual(nutritionOfItem(bread, water, 0.125), { food: 1, water: 0 });
+});
+
+test("things Simple Nutrition would not list are not nutrition", () => {
+  assert.equal(nutritionOfItem({ ...bread, type: "loot" }, water, 0.125), null);
+  assert.equal(nutritionOfItem({ ...bread, consumableType: "potion" }, water, 0.125), null);
+  assert.equal(nutritionOfItem({ ...bread, weightLb: 0 }, water, 0.125), null);
+  assert.equal(nutritionOfItem({ ...bread, identifier: "waterskin" }, water, 0.125), null);
+  // loose water needs a waterskin around it; that is Simple Nutrition's call, not ours
+  assert.equal(nutritionOfItem({ ...ale, identifier: "water-pint" }, water, 0.125), null);
+});
+
+test("a use only counts when it actually consumed the item", () => {
+  assert.equal(usageConsumes({}), true);
+  assert.equal(usageConsumes({ consume: true }), true);
+  assert.equal(usageConsumes({ consume: { resources: true } }), true);
+  assert.equal(usageConsumes({ consume: { resources: [0] } }), true);
+  assert.equal(usageConsumes({ consume: false }), false);
+  assert.equal(usageConsumes({ consume: { resources: false } }), false);
+  assert.equal(usageConsumes({ consume: { resources: [] } }), false);
+});


### PR DESCRIPTION
# What does this PR change?

Closes #19

Simple Nutrition 5e 0.5.0 only records nutrition from its own dialog — it has no item-use hook — so using the Consume activity on ale, wine, bread or cheese from the sheet decremented the item and fed nobody.

- `scripts/nutrition.mjs`: `nutritionOfItem()` mirrors Simple Nutrition's `getFoodCandidates`/`getWaterCandidates` rules (registered drink → one pint of water; other `food` consumables → food by weight; loose `water-pint`, waterskins and non-consumables → not nutrition), and `usageConsumes()` reads whether the dnd5e usage dialog had consumption ticked. Both pure, both unit-tested.
- `scripts/merchant-presets.mjs`: `countActivityMeal()` on `dnd5e.postUseActivity` (fires only on the using client, which owns the character), scoped to this module's goods, recording through the same `applyMeal` path as the meal-at-purchase feature. New world setting **Eating from the sheet counts** (default on).
- Upstream request for a general fix: Kapuzenjoe/simple-nutrition-5e#4 — this bridge can go once that lands.

## Checklist

- [x] `npm test` — 15 pass (4 new)
- [ ] Tested in a Foundry V14 `dnd5e` world with Item Piles and Simple Nutrition active — **needs a manual check**: use Wine (Common) from the sheet, confirm the nutrition bar's water rises by a pint and that untick-consumption does not count
- [x] A line under `[Unreleased]` in `CHANGELOG.md`
- [x] No version bump in `module.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss1qtMk17VZzzTo6DLjqJ2