### PR TITLE
Pin add-to-project to a tag that exists

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -39,7 +39,7 @@ jobs:
             echo "PROJECT_PAT and/or PROJECT_URL not set - skipping."
           fi
 
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v2
         if: steps.check.outputs.configured == 'true'
         with:
           project-url: ${{ vars.PROJECT_URL }}


### PR DESCRIPTION
Closes #21

`actions/add-to-project@v1` is not a real tag (the action's majors are `v2`, plus exact `v1.0.x` tags), so the workflow failed on every issue opened — before its own not-configured skip. Pinned to `v2`. Maintenance: no changelog entry, no milestone.