### PR TITLE
Milestones hold issues only

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,9 @@ issue ──► milestone ──► branch + PR (Closes #N) ──► main ─�
    | `maintenance` | CI, tooling, docs, dependencies; nothing a GM would notice |
    | `regression`  | worked in a previous release; prioritise it               |
 
-2. **A milestone is a planned release**, named after its tag: `v1.2.0`. Assign
+2. **A milestone is a planned release**, named after its tag `v1.2.0`, and holds *issues only* —
+   PRs stay out of milestones (they say `Closes #N` instead), so the progress
+   bar counts each piece of work once. Assign
    an issue to a milestone when you intend to ship it there; leave it
    unassigned while it is only a wish. The milestone's progress bar is the
    release plan, and a bug found after a release goes into the next patch
@@ -46,7 +48,7 @@ rest):
 git checkout main && git pull
 npm run release:prepare -- 1.2.0      # bumps module.json, rolls the changelog, commits on release/v1.2.0
 git push -u origin release/v1.2.0
-gh pr create --fill --milestone v1.2.0
+gh pr create --fill
 ```
 
 Review the `[1.2.0]` section — it becomes the release body — and merge once


### PR DESCRIPTION
A PR in a milestone double-counts the issue it closes, and the release PR is not planned work — drop `--milestone` from the release-PR command in RELEASING.md and state the issues-only convention. Docs only.