### PR TITLE
Ignore local CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Thumbs.db
 .idea/
 .vscode/
 tools/__pycache__/
+
+# Local Claude Code guidance — per-machine, never published.
+CLAUDE.md


### PR DESCRIPTION
Local per-machine Claude Code guidance stays untracked, same as other local notes. Docs/config only.