### PR TITLE
Keep the manifest description free of counts and stock figures

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
-  "description": "<p>Fifty-one ready-made shops as Item Piles merchants — seventeen stores in Village, Town and City sizes, each pre-stocked and priced.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0) plus this module's own goods for the services the books print as table rows rather than items, so it works in any dnd5e world and redistributes no paid content.</p><p>Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
+  "description": "<p>Ready-made shops as Item Piles merchants — each store in village, town and city sizes, pre-stocked and priced. Drag one out of the compendium, drop a token, and your players can shop.</p><p>Shops behave like shops: stock is rolled rather than flat, coin purses are finite and scaled to the trade, merchants only buy what they deal in, and every shop opens, closes and restocks on Foundry's own world clock. Services the rules print as table rows rather than items — meals, lodging, stabling, passage, spellcasting — ship as sellable goods.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0), so it works in any dnd5e world and redistributes no paid content. Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
   "version": "1.2.0",
   "compatibility": {
     "minimum": "14",


### PR DESCRIPTION
Closes #26

The `module.json` description named the shop and store counts — details that go stale on any content change, and the Foundry package listing has to be synced by hand (no API for it).

The rewritten description keeps only what survives adding or removing shops: the village/town/city structure, the shop behaviours (rolled stock, finite purses, buy filters, trading hours and restocking), the services-as-goods point, the SRD-only sourcing and the credit. Wording follows the current foundryvtt.com listing copy so the two stay easy to keep in sync.

Mirrors mikiross87/light-presets#20.

No CHANGELOG entry: manifest metadata is maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Xr6Jk9gfTDFdGYydgUAbd