### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ than for the code. Reference the issue or PR it closes.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-25
+
 ### Fixed
 
 - Using the Consume activity on ale, wine, bread or cheese from the character
@@ -68,7 +70,8 @@ than for the code. Reference the issue or PR it closes.
 - Containers stocked as separate items, one each
 - Original item descriptions and SRD prices throughout
 
-[Unreleased]: https://github.com/mikiross87/merchant-presets/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/mikiross87/merchant-presets/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/mikiross87/merchant-presets/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/mikiross87/merchant-presets/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mikiross87/merchant-presets/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mikiross87/merchant-presets/releases/tag/v1.0.0

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "merchant-presets",
   "title": "Merchant Presets — Shops for 5e",
   "description": "<p>Ready-made shops as Item Piles merchants — each store in village, town and city sizes, pre-stocked and priced. Drag one out of the compendium, drop a token, and your players can shop.</p><p>Shops behave like shops: stock is rolled rather than flat, coin purses are finite and scaled to the trade, merchants only buy what they deal in, and every shop opens, closes and restocks on Foundry's own world clock. Services the rules print as table rows rather than items — meals, lodging, stabling, passage, spellcasting — ship as sellable goods.</p><p>Built entirely from <strong>SRD 5.2</strong> (CC-BY-4.0), so it works in any dnd5e world and redistributes no paid content. Inspired by The Inspired Arcana's free homebrew shop guide.</p>",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14"


### PR DESCRIPTION
Patch release for milestone v1.2.1: bumps `module.json` to 1.2.1 and rolls `[Unreleased]` into a `[1.2.1]` changelog section, which becomes the release body.

### Fixed

- Using the Consume activity on ale, wine, bread or cheese from the character sheet now counts towards Simple Nutrition 5e (#19)

After merge, tag `main`'s HEAD as `v1.2.1` to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgESAk3E7xB5Hu28cgNhsS