### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -39,7 +39,7 @@ jobs:
             echo "PROJECT_PAT and/or PROJECT_URL not set - skipping."
           fi
 
-      - uses: actions/add-to-project@v2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         if: steps.check.outputs.configured == 'true'
         with:
           project-url: ${{ vars.PROJECT_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -37,7 +37,7 @@ jobs:
       # .sh file. The published image bundles shellcheck, so there is nothing
       # to install and no second version to keep in step.
       - name: Lint workflows
-        uses: docker://rhysd/actionlint:1.7.12
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
         with:
           args: -color
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
           cat release-notes.md
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: release-notes.md
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # Deliberately scoped to issues already waiting on the reporter.
           # Untriaged issues are the maintainer's backlog, not the reporter's

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -24,7 +24,7 @@ jobs:
       LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
     steps:
       # Needed only to read the Item Piles minimum out of module.json.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Label and comment from the form answers
         run: |


### PR DESCRIPTION
Closes #29

Every action in `.github/workflows/` was referenced by a mutable major tag and the actionlint image by tag alone. This pins each to the commit the tag currently resolves to, with the version as a trailing comment so it stays readable and Dependabot's `github-actions` updater (already configured, monthly) can keep both in step:

| action | pinned | version |
|---|---|---|
| `actions/checkout` | `3d3c42e5` | v7.0.1 |
| `actions/setup-node` | `82076278` | v7.0.0 |
| `actions/add-to-project` | `5afcf98f` | v2.0.0 |
| `actions/stale` | `5bef64f1` | v9.1.0 |
| `softprops/action-gh-release` | `3d0d9888` | v3.0.2 |
| `docker://rhysd/actionlint:1.7.12` | `@sha256:b1934ee5…` | 1.7.12 |

Once merged, the repository's **Require actions to be pinned to a full-length commit SHA** setting is switched on so a future tag reference fails at workflow validation.

Maintenance only — no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgESAk3E7xB5Hu28cgNhsS