### PR TITLE
Leave the release PR out of the milestone in the release:prepare hint

### DIFF
--- a/tools/prepare-release.mjs
+++ b/tools/prepare-release.mjs
@@ -68,7 +68,7 @@ Staged v${version} on ${release} (${module_.version} -> ${version}).
 Review the [${version}] section of CHANGELOG.md, then:
 
   git push -u origin ${release}
-  gh pr create --fill --milestone v${version}
+  gh pr create --fill
 
 After the PR merges, tag main (never the release branch) — see RELEASING.md:
 


### PR DESCRIPTION
Closes #31

The closing hint in `tools/prepare-release.mjs` still said `gh pr create --fill --milestone v<version>`; milestones hold issues only since #23, and RELEASING.md already shows the plain `gh pr create --fill`. Removes the flag. Same one-line change lands in light-presets so the shared file stays identical.

Maintenance only — no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgESAk3E7xB5Hu28cgNhsS