### PR TITLE
Relink copied spells to their copied features so caster merchants show a spellbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ than for the code. Reference the issue or PR it closes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Shopkeepers who can cast — the Temple, and the town and city Alchemist,
+  Druidic, Arcane and Tinkering stores — now show their spells on the Spells
+  tab. Their spells were copied with a link to the wrong feature, so the sheet
+  hid them and casting through Divine Aid or Spellcasting left a stray copy on
+  the merchant. Merchants already in a world keep the old links; drag a fresh
+  one from the compendium. (#36)
+
 ## [1.2.1] - 2026-08-25
 
 ### Fixed

--- a/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
+++ b/_source/merchants/Alchemists_Apothecaries_City_G2FcMKWlcxCEX2vZ.json
@@ -4571,7 +4571,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4810,7 +4810,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.2HDHPkwefVWFOzlW"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.2HDHPkwefVWFOzlW"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5051,7 +5051,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.kRFj55nvsQK6tgYJ"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.kRFj55nvsQK6tgYJ"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5266,7 +5266,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.nkTQoVkqdDGCEbsC"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.nkTQoVkqdDGCEbsC"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5506,7 +5506,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.mknEHePWqzWQ3BAI"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.mknEHePWqzWQ3BAI"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5748,7 +5748,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.k6VQ3W6iKHSqJlZg"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.k6VQ3W6iKHSqJlZg"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5962,7 +5962,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.qhGxfRb2sww4YJKs"
+          "cachedFor": ".Item.YxWwQVHfYC43Qbgw.Activity.qhGxfRb2sww4YJKs"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
+++ b/_source/merchants/Alchemists_Apothecaries_Town_AJOSFf4SWAuYEJJJ.json
@@ -4033,7 +4033,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.g9C9fpj3tVvI6vhn.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4241,7 +4241,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.g9C9fpj3tVvI6vhn.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4550,7 +4550,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmDivineAid00000.Activity.CNGV8z0AGMkv8u8E"
+          "cachedFor": ".Item.g9C9fpj3tVvI6vhn.Activity.CNGV8z0AGMkv8u8E"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4771,7 +4771,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.jvyAl3Jszzvv1ScY.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4964,7 +4964,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.o8YMf9MB4UV7Oze6"
+          "cachedFor": ".Item.jvyAl3Jszzvv1ScY.Activity.o8YMf9MB4UV7Oze6"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
+++ b/_source/merchants/Arcane_Store_City_5orkNAaxcp1pokP1.json
@@ -5573,7 +5573,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmMistyStep00000.Activity.sstmyMnemXbXqI5Y"
+          "cachedFor": ".Item.R16wD9Mrt4yHp9ot.Activity.sstmyMnemXbXqI5Y"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5987,7 +5987,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmProtectiveMagi.Activity.Jc8kZLhCdTcbaImH"
+          "cachedFor": ".Item.oNp3d12us7V2IYj1.Activity.Jc8kZLhCdTcbaImH"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6239,7 +6239,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmProtectiveMagi.Activity.1rK9SlZ7cBWEeWnG"
+          "cachedFor": ".Item.oNp3d12us7V2IYj1.Activity.1rK9SlZ7cBWEeWnG"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6482,7 +6482,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6703,7 +6703,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.HG2b5wxfWJIqibz2"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.HG2b5wxfWJIqibz2"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6949,7 +6949,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.yRyZDoilcqPhpV9W"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.yRyZDoilcqPhpV9W"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7171,7 +7171,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.pGxN95dMxeflMZEo"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.pGxN95dMxeflMZEo"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7356,7 +7356,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.OYMNE2wRCgV8YaV3"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.OYMNE2wRCgV8YaV3"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7574,7 +7574,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.OMMdgcswZDwcu4P9"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.OMMdgcswZDwcu4P9"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7810,7 +7810,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.PsQU2yHchoO5kFLT"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.PsQU2yHchoO5kFLT"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8022,7 +8022,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.cDga1NaxiuzNOPlP"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.cDga1NaxiuzNOPlP"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8269,7 +8269,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.F9pGhXppRUa1chuR"
+          "cachedFor": ".Item.raVpyMXvi1GZ44Tn.Activity.F9pGhXppRUa1chuR"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
+++ b/_source/merchants/Arcane_Store_Town_jPD3BvWzH3u1dKob.json
@@ -4534,7 +4534,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.0cZLAf7EyBkrUGc2.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4742,7 +4742,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.0cZLAf7EyBkrUGc2.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5051,7 +5051,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmDivineAid00000.Activity.CNGV8z0AGMkv8u8E"
+          "cachedFor": ".Item.0cZLAf7EyBkrUGc2.Activity.CNGV8z0AGMkv8u8E"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5272,7 +5272,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.pt8YkisVjZ40wfh7.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5465,7 +5465,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.o8YMf9MB4UV7Oze6"
+          "cachedFor": ".Item.pt8YkisVjZ40wfh7.Activity.o8YMf9MB4UV7Oze6"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
+++ b/_source/merchants/Druidic_Store_City_hekewkxL1oj7zZuv.json
@@ -8086,7 +8086,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8325,7 +8325,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.2HDHPkwefVWFOzlW"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.2HDHPkwefVWFOzlW"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8566,7 +8566,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.kRFj55nvsQK6tgYJ"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.kRFj55nvsQK6tgYJ"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8781,7 +8781,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.nkTQoVkqdDGCEbsC"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.nkTQoVkqdDGCEbsC"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -9021,7 +9021,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.mknEHePWqzWQ3BAI"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.mknEHePWqzWQ3BAI"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -9263,7 +9263,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.k6VQ3W6iKHSqJlZg"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.k6VQ3W6iKHSqJlZg"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -9477,7 +9477,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.qhGxfRb2sww4YJKs"
+          "cachedFor": ".Item.Ciwb5yAyr4MFpnVX.Activity.qhGxfRb2sww4YJKs"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
+++ b/_source/merchants/Druidic_Store_Town_U8H1pzdwNLWTLNyn.json
@@ -7327,7 +7327,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.hs8i0vBk0CyAC0rJ.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7535,7 +7535,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.hs8i0vBk0CyAC0rJ.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7844,7 +7844,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmDivineAid00000.Activity.CNGV8z0AGMkv8u8E"
+          "cachedFor": ".Item.hs8i0vBk0CyAC0rJ.Activity.CNGV8z0AGMkv8u8E"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8065,7 +8065,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.aXPsbtzfSCEXCXae.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8258,7 +8258,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.o8YMf9MB4UV7Oze6"
+          "cachedFor": ".Item.aXPsbtzfSCEXCXae.Activity.o8YMf9MB4UV7Oze6"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
+++ b/_source/merchants/Temple_Faith_Store_City_8O5pvxug7VBAjahW.json
@@ -5555,7 +5555,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.nRu69XCQ7exdH7Ts.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5753,7 +5753,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.R4x9qJ4BYyFenPUf"
+          "cachedFor": ".Item.nRu69XCQ7exdH7Ts.Activity.R4x9qJ4BYyFenPUf"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5961,7 +5961,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.nRu69XCQ7exdH7Ts.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6158,7 +6158,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.mV8EoRveUz19SU1p"
+          "cachedFor": ".Item.nRu69XCQ7exdH7Ts.Activity.mV8EoRveUz19SU1p"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6379,7 +6379,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.M4sHJBjcNBzToYj4.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6572,7 +6572,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.ILNWEY9GzFvdXgjx"
+          "cachedFor": ".Item.M4sHJBjcNBzToYj4.Activity.ILNWEY9GzFvdXgjx"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6797,7 +6797,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.dZUIjm3iQXmEpRLf"
+          "cachedFor": ".Item.M4sHJBjcNBzToYj4.Activity.dZUIjm3iQXmEpRLf"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
+++ b/_source/merchants/Temple_Faith_Store_Town_v5K6ycEOTlSO5K4N.json
@@ -4857,7 +4857,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.7c1BwA97yc0ReOtr.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5065,7 +5065,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.7c1BwA97yc0ReOtr.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5374,7 +5374,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmDivineAid00000.Activity.CNGV8z0AGMkv8u8E"
+          "cachedFor": ".Item.7c1BwA97yc0ReOtr.Activity.CNGV8z0AGMkv8u8E"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5595,7 +5595,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.Jtv71NCZLCPLFaeC.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -5788,7 +5788,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.o8YMf9MB4UV7Oze6"
+          "cachedFor": ".Item.Jtv71NCZLCPLFaeC.Activity.o8YMf9MB4UV7Oze6"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
+++ b/_source/merchants/Temple_Faith_Store_Village_MLTOIp7Dsy7NlAgx.json
@@ -3955,7 +3955,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.V0Qrt1uTAqiU9SCm"
+          "cachedFor": ".Item.ycBIaP5wVzBSvj5m.Activity.V0Qrt1uTAqiU9SCm"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4163,7 +4163,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmDivineAid00000.Activity.xlmEmICWCOXh1DRs"
+          "cachedFor": ".Item.ycBIaP5wVzBSvj5m.Activity.xlmEmICWCOXh1DRs"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4472,7 +4472,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmDivineAid00000.Activity.CNGV8z0AGMkv8u8E"
+          "cachedFor": ".Item.ycBIaP5wVzBSvj5m.Activity.CNGV8z0AGMkv8u8E"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4693,7 +4693,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.IRw5F2XwP6moEZL5.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -4886,7 +4886,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.o8YMf9MB4UV7Oze6"
+          "cachedFor": ".Item.IRw5F2XwP6moEZL5.Activity.o8YMf9MB4UV7Oze6"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
+++ b/_source/merchants/Tinkering_Store_City_RYY3iNLTVuaAGh5c.json
@@ -6334,7 +6334,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmMistyStep00000.Activity.sstmyMnemXbXqI5Y"
+          "cachedFor": ".Item.yPkSWIMn8pHdp6JX.Activity.sstmyMnemXbXqI5Y"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -6748,7 +6748,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmProtectiveMagi.Activity.Jc8kZLhCdTcbaImH"
+          "cachedFor": ".Item.Vwztlp2y3loxIam4.Activity.Jc8kZLhCdTcbaImH"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7000,7 +7000,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmProtectiveMagi.Activity.1rK9SlZ7cBWEeWnG"
+          "cachedFor": ".Item.Vwztlp2y3loxIam4.Activity.1rK9SlZ7cBWEeWnG"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7243,7 +7243,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.3MkhXZwZstyLUC3q"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.3MkhXZwZstyLUC3q"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7464,7 +7464,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.HG2b5wxfWJIqibz2"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.HG2b5wxfWJIqibz2"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7710,7 +7710,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.yRyZDoilcqPhpV9W"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.yRyZDoilcqPhpV9W"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -7932,7 +7932,7 @@
             "activity": [],
             "effect": []
           },
-          "cachedFor": ".Item.mmSpellcasting00.Activity.pGxN95dMxeflMZEo"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.pGxN95dMxeflMZEo"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8117,7 +8117,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.OYMNE2wRCgV8YaV3"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.OYMNE2wRCgV8YaV3"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8335,7 +8335,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.OMMdgcswZDwcu4P9"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.OMMdgcswZDwcu4P9"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8571,7 +8571,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.PsQU2yHchoO5kFLT"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.PsQU2yHchoO5kFLT"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -8783,7 +8783,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.cDga1NaxiuzNOPlP"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.cDga1NaxiuzNOPlP"
         },
         "merchant-presets": {
           "kind": "gear"
@@ -9030,7 +9030,7 @@
       ],
       "flags": {
         "dnd5e": {
-          "cachedFor": ".Item.mmSpellcasting00.Activity.F9pGhXppRUa1chuR"
+          "cachedFor": ".Item.SqTjaxPkDY61AbYw.Activity.F9pGhXppRUa1chuR"
         },
         "merchant-presets": {
           "kind": "gear"

--- a/tools/build_srd.py
+++ b/tools/build_srd.py
@@ -245,6 +245,22 @@ def make_item(src, line, actor_id, uuid, own, tier_index, copy=0):
         eff["origin"] = None
     return it, is_container
 
+# A stat block's spells are dnd5e "cached spells": each carries
+# `flags.dnd5e.cachedFor`, a uuid relative to the actor that names the feature
+# whose Cast activity granted it — `.Item.<feature id>.Activity.<activity id>`.
+# dnd5e resolves it with `actor.items.get(<feature id>)`, so once make_gear
+# re-ids the feature the link dangles: the sheet drops the spell from the
+# spellbook, and casting clones a fresh, untagged copy onto the merchant.
+# `fid` is a pure hash, so the new feature id is known before it is made.
+CACHED_FOR = re.compile(r"\.Item\.([^.]+)\.Activity\.([^.]+)")
+
+def relink_cached_for(flag, actor_id):
+    """Point a copied spell's `cachedFor` at the copied feature."""
+    m = CACHED_FOR.fullmatch(flag or "")
+    if not m:
+        return flag
+    return f".Item.{fid(actor_id, 'gear', m[1])}.Activity.{m[2]}"
+
 def make_gear(src, actor_id, srd, feats):
     """Copy one item off a stat block onto a merchant.
 
@@ -295,6 +311,9 @@ def make_gear(src, actor_id, srd, feats):
 
     flags = it.setdefault("flags", {})
     flags.setdefault("merchant-presets", {})["kind"] = "gear"
+    cached = (flags.get("dnd5e") or {}).get("cachedFor")
+    if cached:
+        flags["dnd5e"]["cachedFor"] = relink_cached_for(cached, actor_id)
 
     it["_id"] = iid
     it["_key"] = f"!actors.items!{actor_id}.{iid}"


### PR DESCRIPTION
Closes #36

The stat block's spells are dnd5e *cached spells*: each carries `flags.dnd5e.cachedFor`, a uuid relative to the actor naming the feature that casts it **by embedded item id**. `make_gear` re-ids every gear item but never rewrote those links, so on a merchant they dangled — the NPC sheet hid the spells (`linkedActivity` resolves to nothing), and using Divine Aid / Spellcasting cloned a stray, untagged copy onto the merchant.

`fid()` is a pure hash, so the copied feature's id is known before it is made: `relink_cached_for` rewrites the item segment of `cachedFor` to `fid(actor_id, "gear", <old id>)`.

`_source/merchants` regenerated against dnd5e 5.3.3 — the diff is exactly the 70 `cachedFor` lines across the ten caster merchants, nothing else, so regeneration is still deterministic. Verified every `cachedFor` on every merchant now resolves to an item on that actor and to an activity on it.

Existing world actors keep the old links; a GM re-drops the merchant. CHANGELOG entry under Unreleased.

Noticed alongside, not fixed here: the SRD `actors24` Priest Acolyte's Divine Aid *description* lists the CR 2 Priest's spells while its activities (and SRD 5.2) cast Bless / Healing Word / Sanctuary — a dnd5e data bug we copy verbatim, to report upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgESAk3E7xB5Hu28cgNhsS